### PR TITLE
Fix typo in index.mdx

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -16,7 +16,7 @@ limitations under the License.
 
 # 🤗 Optimum TPU
 
-Optimum TPU provides all the necessary machinery to leverage and optimize AI workloads runningo on [Google Cloud TPU devices](https://cloud.google.com/tpu/docs).
+Optimum TPU provides all the necessary machinery to leverage and optimize AI workloads running on [Google Cloud TPU devices](https://cloud.google.com/tpu/docs).
 
 The API provides the overall same user-experience as Hugging Face transformers with the minimum amount of changes required to target performance for inference.
 


### PR DESCRIPTION
Fix "runningo" instead of "running" in `index.mdx`