### PR TITLE
Fix optimum-tpu pip install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We currently support a few LLM models targeting text generation scenarios:
 
 `optimum-tpu` comes with an handy PyPi released package compatible with your classical python dependency management tool.
 
-`pip install optimum-tpu`
+`pip install optimum-tpu -f https://storage.googleapis.com/libtpu-releases/index.html`
 
 ## Inference
 

--- a/docs/source/howto/deploy.mdx
+++ b/docs/source/howto/deploy.mdx
@@ -65,7 +65,7 @@ $ >
 If you want to leverage PyTorch/XLA through Optimum-TPU, it should be as simple as
 
 ```bash
-$ python3 -m pip install optimum-tpu
+$ python3 -m pip install optimum-tpu -f https://storage.googleapis.com/libtpu-releases/index.html
 $ export PJRT_DEVICE=TPU
 ```
 


### PR DESCRIPTION
We need to provide the find-links option to pip to find libtpu on Google storage