### PR TITLE
fix(build): setup.py removed from build_dist dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ PACKAGE_DIST = dist/optimum-tpu-$(VERSION).tar.gz
 PACKAGE_WHEEL = dist/optimum_tpu-$(VERSION)-py3-none-any.whl
 PACKAGE_PYTHON_FILES = $(call rwildcard, optimum/*.py)
 PACKAGE_FILES = $(PACKAGE_PYTHON_FILES)  \
-				setup.py \
 				setup.cfg \
 				pyproject.toml \
 				README.md \


### PR DESCRIPTION
# What does this PR do?
Fix build_dist target, that was broken because depending on a file that does not exist anymore.
