### PR TITLE
Mistral nits

### DIFF
--- a/optimum/tpu/modeling_mistral.py
+++ b/optimum/tpu/modeling_mistral.py
@@ -1634,6 +1634,8 @@ class MistralForTokenClassification(MistralPreTrainedModel):
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
         # Unless specified otherwise, the model weights type will be bfloat16
+        if "torch_dtype" not in kwargs:
+            logger.warning_once("Defaulting to `torch_dtype=torch.bfloat16` for this model")
         torch_dtype = kwargs.pop("torch_dtype", torch.bfloat16)
         # forward to base implementation
         return super().from_pretrained(pretrained_model_name_or_path, *model_args, torch_dtype=torch_dtype, **kwargs)

--- a/optimum/tpu/modeling_mistral.py
+++ b/optimum/tpu/modeling_mistral.py
@@ -1630,3 +1630,10 @@ class MistralForTokenClassification(MistralPreTrainedModel):
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
         )
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
+        # Unless specified otherwise, the model weights type will be bfloat16
+        torch_dtype = kwargs.pop("torch_dtype", torch.bfloat16)
+        # forward to base implementation
+        return super().from_pretrained(pretrained_model_name_or_path, *model_args, torch_dtype=torch_dtype, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ dependencies = [
     "transformers == 4.41.1",
     "torch >= 2.3.0, <= 2.4.0",
     "torch-xla[tpu] >= 2.3.0, <= 2.4.0",
-    "loguru == 0.6.0"
+    "loguru == 0.6.0",
+    "sentencepiece == 0.2.0",
 ]
 
 [tool.setuptools_scm]

--- a/text-generation-inference/server/pyproject.toml
+++ b/text-generation-inference/server/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     'safetensors == 0.4.2',
     'transformers == 4.41.1',
     'loguru == 0.6.0',
+    "sentencepiece == 0.2.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
- Add missing dependency on `sentencepiece` that is making the nightly CI fail.
- Serve mistral in `bfloat16` by default.
