### PR TITLE
chore: bump to version v0.1.0a1

### DIFF
--- a/optimum/tpu/version.py
+++ b/optimum/tpu/version.py
@@ -15,5 +15,5 @@
 from pkg_resources import parse_version
 
 
-__version__ = "0.1.0a0"
+__version__ = "0.1.0a1"
 VERSION = parse_version(__version__)

--- a/text-generation-inference/server/text_generation_server/version.py
+++ b/text-generation-inference/server/text_generation_server/version.py
@@ -1,5 +1,5 @@
 from pkg_resources import parse_version
 
 
-__version__ = "0.1.0a0"
+__version__ = "0.1.0a1"
 VERSION = parse_version(__version__)


### PR DESCRIPTION
Simple bump to v0.1.0a1 to get a cleaner version for a container image.
