### PR TITLE
TGI version is not being passed through to the server make command in Dockerfile

### DIFF
--- a/text-generation-inference/docker/Dockerfile
+++ b/text-generation-inference/docker/Dockerfile
@@ -74,7 +74,7 @@ WORKDIR /pyserver
 COPY text-generation-inference/server server
 COPY --from=tgi /tgi/proto proto
 RUN pip3 install -r server/build-requirements.txt
-RUN VERBOSE=1 BUILDDIR=/pyserver/build PROTODIR=/pyserver/proto VERSION=${VERSION} make -C server gen-server
+RUN VERBOSE=1 BUILDDIR=/pyserver/build PROTODIR=/pyserver/proto TGI_VERSION=${TGI_VERSION} VERSION=${VERSION} make -C server gen-server
 
 # TPU base image (used for deployment)
 FROM base AS tpu_base


### PR DESCRIPTION
I was working with this Dockerfile, and I noticed that TGI_VERSION is not properly passed through from the Dockerfile into the Makefile for the server files.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
