### PR TITLE
Several Inference Endpoint fixes

### DIFF
--- a/.github/workflows/tpu-tgi-release.yml
+++ b/.github/workflows/tpu-tgi-release.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   release:
+    types: [published]
 
 jobs:
   docker:

--- a/text-generation-inference/docker/entrypoint.sh
+++ b/text-generation-inference/docker/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# This is required by GKE, see
+# https://cloud.google.com/kubernetes-engine/docs/how-to/tpus#privileged-mode
+ulimit -l 68719476736
+
 # Hugging Face Hub related
 if [[ -z "${MODEL_ID}" ]]; then
   echo "MODEL_ID must be set"

--- a/text-generation-inference/docker/entrypoint.sh
+++ b/text-generation-inference/docker/entrypoint.sh
@@ -7,38 +7,7 @@ if [[ -z "${MODEL_ID}" ]]; then
 fi
 export MODEL_ID="${MODEL_ID}"
 
-# TGI related
-if [[ -n "${TGI_MAX_CONCURRENT_REQUESTS}" ]]; then
-  export TGI_MAX_CONCURRENT_REQUESTS="${TGI_MAX_CONCURRENT_REQUESTS}"
-else
-  export TGI_MAX_CONCURRENT_REQUESTS=4
-fi
-
-if [[ -n "${TGI_MAX_BATCH_SIZE}" ]]; then
-  export TGI_MAX_BATCH_SIZE="${TGI_MAX_BATCH_SIZE}"
-else
-  export TGI_MAX_BATCH_SIZE=1
-fi
-
-if [[ -n "${TGI_MAX_INPUT_TOKENS}" ]]; then
-  export TGI_MAX_INPUT_TOKENS="${TGI_MAX_INPUT_TOKENS}"
-else
-  export TGI_MAX_INPUT_TOKENS=32
-fi
-
-if [[ -n "${TGI_MAX_TOTAL_TOKENS}" ]]; then
-  export TGI_MAX_TOTAL_TOKENS="${TGI_MAX_TOTAL_TOKENS}"
-else
-  export TGI_MAX_TOTAL_TOKENS=64
-fi
-
-TGI_MAX_BATCH_PREFILL_TOKENS=$(( TGI_MAX_BATCH_SIZE*TGI_MAX_INPUT_TOKENS ))
-
 text-generation-launcher --port 8080 \
-  --max-concurrent-requests ${TGI_MAX_CONCURRENT_REQUESTS} \
-  --max-batch-size ${TGI_MAX_BATCH_SIZE} \
-  --max-batch-prefill-tokens ${TGI_MAX_BATCH_PREFILL_TOKENS} \
-  --max-input-tokens ${TGI_MAX_INPUT_TOKENS} \
-  --max-total-tokens ${TGI_MAX_TOTAL_TOKENS} \
+  --max-batch-size 4 \
   --model-id ${MODEL_ID}
 

--- a/text-generation-inference/server/pyproject.toml
+++ b/text-generation-inference/server/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     'transformers == 4.41.1',
     'loguru == 0.6.0',
     "sentencepiece == 0.2.0",
+    "numpy<2.0",
 ]
 
 [tool.setuptools]

--- a/text-generation-inference/server/text_generation_server/generator.py
+++ b/text-generation-inference/server/text_generation_server/generator.py
@@ -618,7 +618,7 @@ class TpuGeneratorSingleThread(Generator):
     def _clear(self, keep_slot_ids: List):
         for slot in self.slots:
             if slot.state != Slot.State.EMPTY and slot.id not in keep_slot_ids:
-                logger.info(f"Removing slot {slot.id} with request {slot.request_id}")
+                logger.debug(f"Removing slot {slot.id} with request {slot.request_id}")
                 slot.clear()
 
     @classmethod

--- a/text-generation-inference/server/text_generation_server/generator.py
+++ b/text-generation-inference/server/text_generation_server/generator.py
@@ -317,6 +317,7 @@ class TpuGeneratorSingleThread(Generator):
                 f"Inconsistent server configuration: please make sure max-prefill-tokens does not exceed {batch_size} x max-input-length."
             )
         self.prefill(batch)
+        self.clear()
         return batch_size * self.model.config.sequence_length
 
     @torch.no_grad

--- a/text-generation-inference/server/text_generation_server/generator.py
+++ b/text-generation-inference/server/text_generation_server/generator.py
@@ -3,7 +3,7 @@ import logging
 import os
 import time
 from enum import Enum
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
 import torch.multiprocessing as mp
@@ -52,6 +52,7 @@ class Slot:
     def clear(self):
         """Clear the slot and mark it as available."""
         self._state = Slot.State.EMPTY
+        self._batch_id = None
         self._request_id = None
         self._inputs = ""
         self._generation_config = None
@@ -73,6 +74,10 @@ class Slot:
     @property
     def state(self) -> "Slot.State":
         return self._state
+
+    @property
+    def batch_id(self) -> int:
+        return self._batch_id
 
     @property
     def request_id(self) -> int:
@@ -98,16 +103,18 @@ class Slot:
     def truncate(self) -> int:
         return self._truncate
 
-    def assign(self, request: Request, generation_config: GenerationConfig):
+    def assign(self, batch_id: int, request: Request, generation_config: GenerationConfig):
         """Assign a request to a slot.
 
         Args:
+            batch_id (`int`): The id of the batch containing the request.
             request (`Request`):
                 The request to be assigned. Contains the inputs and tokens selection parameters.
             generation_config (`transformers.GenerationConfig`):
                 The base generation config (might be modified by the request generation parameters).
         """
         self._state = Slot.State.READY
+        self._batch_id = batch_id
         self._request_id = request.id
         self._inputs = request.inputs
         self._generation_config = copy.deepcopy(generation_config)
@@ -122,6 +129,7 @@ class Slot:
         self.seed = request.parameters.seed
         # TODO: watermark
         self._generation_config.max_new_tokens = request.stopping_parameters.max_new_tokens
+        self._max_new_tokens = self._generation_config.max_new_tokens
         # TODO: stop_sequences, ignore_eos_token
 
     def reset(self, input_ids: torch.LongTensor, attention_mask: torch.LongTensor, selector: TokenSelector):
@@ -152,8 +160,9 @@ class Slot:
         """
         # Drop the last token as it will be added back when resuming the slot
         self._generated_tokens -= 1
-        # Subtract the number of cached tokens from the maximum number of tokens
-        self._generation_config.max_new_tokens -= self._generated_tokens
+        # Since generated tokens are now part of the prefill, we need to reevaluate
+        # max_new_tokens for the next generation
+        self._generation_config.max_new_tokens = self._max_new_tokens - self._generated_tokens
         self._state = Slot.State.PAUSE
 
     def resume(self):
@@ -267,6 +276,7 @@ class TpuGeneratorSingleThread(Generator):
         self.special_tokens = self.tokenizer.all_special_ids
         # Slots are empty to begin with, they will be populated as new batches arrive
         self.slots = []
+        self.batch_id = 0
         # Note: this index will _never_ be decremented, and that's fine.
         self.slot_index = 0
         self.past_key_values = None
@@ -345,7 +355,7 @@ class TpuGeneratorSingleThread(Generator):
             # Dynamically create a new slot for each request
             slot = Slot(self.slot_index, self.tokenizer, self.model.device)
             self.slot_index += 1
-            slot.assign(request, self.model.generation_config)
+            slot.assign(self.batch_id, request, self.model.generation_config)
             self.slots.append(slot)
             logger.debug(f"Request {slot.request_id} assigned to slot {slot.id}")
         # Reconstruct the full inputs (without padding) as seen by the model.
@@ -418,13 +428,14 @@ class TpuGeneratorSingleThread(Generator):
             # Reset/clear KV cache
             self.past_key_values = None
         generation, next_batch = self._generate_token(
-            batch.id,
+            self.batch_id,
             input_ids.to(self.model.device),
             self.model,
             attention_mask=attention_mask.to(self.model.device),
             position_ids=position_ids.to(self.model.device),
             **extra_args,
         )
+        self.batch_id += 1
 
         # Reactivate previously active slots for the next decode, and append
         # back their next token.
@@ -581,7 +592,7 @@ class TpuGeneratorSingleThread(Generator):
         max_tokens = size * self.model.config.sequence_length
         return CachedBatch(id=batch_id, request_ids=request_ids, size=size, max_tokens=max_tokens)
 
-    def filter(self, batch_id: int, request_ids: List[int]) -> CachedBatch:
+    def filter(self, batch_id: int, keep_request_ids: List[int]) -> CachedBatch:
         """Remove requests that are not listed from the specified batch
 
         Args:
@@ -593,17 +604,21 @@ class TpuGeneratorSingleThread(Generator):
         Return:
             A `CachedBatch` containing the pending requests.
         """
-        self._clear(request_ids)
-        return self._cached_batch(batch_id, request_ids)
+        keep_slot_ids = [slot.id for slot in self.slots if slot.request_id in keep_request_ids]
+        self._clear(keep_slot_ids)
+        return self._cached_batch(batch_id, keep_request_ids)
 
-    def clear(self):
-        """Remove all requests from the generator"""
-        return self._clear([])
+    def clear(self, batch_id: Optional[int] = None):
+        """Remove a subset or all requests from the generator"""
+        keep_ids = []
+        if batch_id is not None:
+            keep_ids = [slot.id for slot in self.slots if slot.batch_id != batch_id]
+        return self._clear(keep_ids)
 
-    def _clear(self, request_ids: List):
+    def _clear(self, keep_slot_ids: List):
         for slot in self.slots:
-            if slot.state != Slot.State.EMPTY and slot.request_id not in request_ids:
-                logger.debug(f"Removing request {slot.request_id}")
+            if slot.state != Slot.State.EMPTY and slot.id not in keep_slot_ids:
+                logger.info(f"Removing slot {slot.id} with request {slot.request_id}")
                 slot.clear()
 
     @classmethod

--- a/text-generation-inference/server/text_generation_server/server.py
+++ b/text-generation-inference/server/text_generation_server/server.py
@@ -27,8 +27,9 @@ class TextGenerationService(generate_pb2_grpc.TextGenerationServiceServicer):
 
     async def ClearCache(self, request, context):
         if request.HasField("id"):
-            logger.warning(f"Clearing all batches instead of batch {request.id} only.")
-        self.generator.clear()
+            self.generator.clear(request.id)
+        else:
+            self.generator.clear()
         return generate_pb2.ClearCacheResponse()
 
     async def FilterBatch(self, request, context):

--- a/text-generation-inference/server/text_generation_server/version.py
+++ b/text-generation-inference/server/text_generation_server/version.py
@@ -1,5 +1,5 @@
 from pkg_resources import parse_version
 
 
-__version__ = "0.1.0a1"
+__version__ = "0.1.1"
 VERSION = parse_version(__version__)

--- a/text-generation-inference/tests/test_generator_slot.py
+++ b/text-generation-inference/tests/test_generator_slot.py
@@ -34,7 +34,7 @@ def test_decode_streaming(tokenizer, input_text, generated_text):
     # Note: device used is cpu to make it faster
     slot = Slot(0, tokenizer, "cpu")
     request = Request(id=0, inputs=input_text)
-    slot.assign(request, GenerationConfig())
+    slot.assign(0, request, GenerationConfig())
     assert slot.cached_text == input_text
 
     inputs = tokenizer(input_text, padding="max_length", max_length=len(input_text) + 1, return_tensors="pt")

--- a/text-generation-inference/tests/test_prefill_truncate.py
+++ b/text-generation-inference/tests/test_prefill_truncate.py
@@ -1,0 +1,35 @@
+from helpers import create_request, prepare_model
+from text_generation_server.generator import TpuGeneratorSingleThread as TpuGenerator
+from text_generation_server.pb.generate_pb2 import Batch
+
+
+def test_prefill_truncate():
+    model_id="Maykeye/TinyLLama-v0"
+    sequence_length=1024
+
+    model_path = prepare_model(model_id, sequence_length)
+    max_new_tokens = 20
+
+    generator = TpuGenerator.from_pretrained(
+        model_path, revision="", max_batch_size=1, max_sequence_length=sequence_length
+    )
+    input_text = "This is a secret part. Once upon a time,"
+
+    request = create_request(id=0, inputs=input_text, max_new_tokens=max_new_tokens, do_sample=False)
+    batch = Batch(id=0, requests=[request], size=1, max_tokens=sequence_length)
+    generations, _ = generator.prefill(batch)
+    assert len(generations) == 1
+    assert generations[0].tokens.ids == [635]
+    assert generations[0].tokens.texts == [" there"]
+
+    # Now re-test but with truncate
+    generator.clear()
+
+    request = create_request(id=0, inputs=input_text, max_new_tokens=max_new_tokens, do_sample=False)
+    # This will only leave 5 tokens
+    request.truncate = 5
+    batch = Batch(id=0, requests=[request], size=1, max_tokens=sequence_length)
+    generations, _ = generator.prefill(batch)
+    assert len(generations) == 1
+    assert generations[0].tokens.ids == [260]
+    assert generations[0].tokens.texts == [" a"]


### PR DESCRIPTION
# What does this PR do?

- Removed variables form entrypoint.sh, they are passed to the launcher via env vars
- Prevent issues with numpy 2.0 version
- correct TGI version
- add GKE ulimit command
- correct CachedBatch serialization when it's None (it was causing health call to crash)
- prefill and decode input pre-processing done in CPU to prevent wasting memory and time in compilation on TPU
- warmup clears after prefill
- fix clear implementation