### PR TITLE
Lower TGI IE batch size

### DIFF
--- a/optimum/tpu/version.py
+++ b/optimum/tpu/version.py
@@ -15,5 +15,5 @@
 from pkg_resources import parse_version
 
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 VERSION = parse_version(__version__)

--- a/text-generation-inference/docker/entrypoint.sh
+++ b/text-generation-inference/docker/entrypoint.sh
@@ -6,7 +6,7 @@ ulimit -l 68719476736
 
 # Hugging Face Hub related
 if [[ -z "${BATCH_SIZE}" ]]; then
-  BATCH_SIZE=4
+  BATCH_SIZE=2
 fi
 export BATCH_SIZE="${BATCH_SIZE}"
 

--- a/text-generation-inference/server/text_generation_server/version.py
+++ b/text-generation-inference/server/text_generation_server/version.py
@@ -1,5 +1,5 @@
 from pkg_resources import parse_version
 
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 VERSION = parse_version(__version__)


### PR DESCRIPTION
# What does this PR do?

This lowers the default batch size to 2 to avoid memory issues with some models, and increments version.