### PR TITLE
chore(tgi): update TGI base image

### DIFF
--- a/.github/workflows/tpu-tgi-release.yml
+++ b/.github/workflows/tpu-tgi-release.yml
@@ -74,7 +74,7 @@ jobs:
             labels: ${{ steps.meta.outputs.labels }}
             build-args: |
               VERSION=${{ steps.version.outputs.version }}
-              TGI_VERSION=5bc3d65dd32ba1f979540caeccbf3dd8798dd9df
+              TGI_VERSION=v2.0.3
 
 
         - name: Generate artifact attestation for TGI
@@ -95,7 +95,7 @@ jobs:
             labels: ${{ steps.meta-ie.outputs.labels }}
             build-args: |
               VERSION=${{ steps.version.outputs.version }}
-              TGI_VERSION=5bc3d65dd32ba1f979540caeccbf3dd8798dd9df
+              TGI_VERSION=v2.0.3
             target: inference-endpoint
 
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ REAL_CLONE_URL = $(if $(CLONE_URL),$(CLONE_URL),$(DEFAULT_CLONE_URL))
 
 .PHONY:	build_dist style style_check clean
 
-TGI_VERSION ?= 5bc3d65dd32ba1f979540caeccbf3dd8798dd9df
+TGI_VERSION ?= v2.0.3
 
 rwildcard=$(wildcard $1) $(foreach d,$1,$(call rwildcard,$(addsuffix /$(notdir $d),$(wildcard $(dir $d)*))))
 

--- a/text-generation-inference/server/Makefile
+++ b/text-generation-inference/server/Makefile
@@ -2,7 +2,7 @@
 pkg_name := text_generation_server
 BUILDDIR ?= $(CURDIR)/build
 VERSION ?= 0.0.1
-TGI_VERSION ?= v2.0.1
+TGI_VERSION ?= v2.0.3
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 mkfile_dir := $(dir $(mkfile_path))
 pkg_dir := $(BUILDDIR)/$(pkg_name)


### PR DESCRIPTION
# What does this PR do?

This will fix the TGI base image to 2.0.3. The protobuf has not changed, everything works the same and it's much cleaner than using a sha1.
