### PR TITLE
Debug instruct UI issue

### DIFF
--- a/optimum/tpu/generation/logits_process.py
+++ b/optimum/tpu/generation/logits_process.py
@@ -48,8 +48,6 @@ class FusedLogitsWarper:
         Returns:
             a `FusedLogitsWarper` or None if neither top-k nor top-p are configured.
         """
-        if generation_config.do_sample and generation_config.top_k == 0 and generation_config.top_p == 1.0:
-            raise ValueError("Multinomial sampling requires at least top-k or top-p to be specified.")
         return cls(generation_config.temperature, generation_config.top_k, generation_config.top_p)
 
     def __call__(self, logits: torch.FloatTensor) -> Tuple[torch.FloatTensor, torch.LongTensor]:
@@ -58,9 +56,6 @@ class FusedLogitsWarper:
 
         do_top_k = self.top_k > 0 and self.top_k < logits.shape[-1]
         do_top_p = self.top_p < 1.0 and self.top_p > 0.0
-
-        if not do_top_k and not do_top_p:
-            return logits, None
 
         if do_top_k:
             sorted_logits, sorted_indices = torch.topk(logits, self.top_k)

--- a/optimum/tpu/version.py
+++ b/optimum/tpu/version.py
@@ -15,5 +15,5 @@
 from pkg_resources import parse_version
 
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 VERSION = parse_version(__version__)

--- a/text-generation-inference/server/text_generation_server/version.py
+++ b/text-generation-inference/server/text_generation_server/version.py
@@ -1,5 +1,5 @@
 from pkg_resources import parse_version
 
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 VERSION = parse_version(__version__)


### PR DESCRIPTION
# What does this PR do?

The logits process is relaxed so it allows top_k =1 and top_p=1 even when do_sample=True. These kind of requests was received when testing instruct models such as `mistralai/Mistral-7B-Instruct-v0.3` with the inference endpoints web ui.
This should fix #76 and #77.
Version is increased, so I can release that and use the new version with the fix in Inference Endpoints.


