### PR TITLE
feat(ci): set `fetch-depth: 0` in trufflehog checkout step

### DIFF
--- a/.github/workflows/secrets-leak.yml
+++ b/.github/workflows/secrets-leak.yml
@@ -9,20 +9,9 @@ jobs:
   trufflehog:
     runs-on: ubuntu-latest
     steps:
-      - shell: bash
-        run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            echo "depth=$(($(jq length <<< '${{ toJson(github.event.commits) }}') + 2))" >> $GITHUB_ENV
-            echo "branch=${{ github.ref_name }}" >> $GITHUB_ENV
-          fi
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "depth=$((${{ github.event.pull_request.commits }}+2))" >> $GITHUB_ENV
-            echo "branch=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
-          fi
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{env.branch}}
-          fetch-depth: ${{env.depth}}
+          fetch-depth: 0
       - name: Secret Scanning
         uses: trufflesecurity/trufflehog@main


### PR DESCRIPTION
This should prevent the issues happening randomly on some commits when bash was having issues escaping some characters.

This is essentially a ripoff from this commit:
https://github.com/huggingface/transformers/pull/31663/commits/3af9e835e44c0acc6595da2db8bb9d28cf6115bf