### PR TITLE
chore(pypi): remove direct dependency to doc-builder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
 tests = ["pytest", "safetensors"]
-quality = ["black", "ruff", "isort", "hf_doc_builder @ git+https://github.com/huggingface/doc-builder.git"]
+quality = ["black", "ruff", "isort"]
 
 [project.urls]
 Homepage = "https://hf.co/hardware"


### PR DESCRIPTION
Removed direct dependency to a repo to avoid errors when publishing to pypi.

