### PR TITLE
fix(ci): install doc builder explicitly

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Setup environment
         run: |
           pip install -U pip
+          pip install git+https://github.com/huggingface/doc-builder.git
           pip install ".[quality]" -f https://storage.googleapis.com/libtpu-releases/index.html
 
       - name: Make documentation

--- a/.github/workflows/doc-pr-build.yml
+++ b/.github/workflows/doc-pr-build.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Setup environment
         run: |
           pip install -U pip
+          pip install git+https://github.com/huggingface/doc-builder.git
           pip install ".[quality]" -f https://storage.googleapis.com/libtpu-releases/index.html
 
       - name: Make documentation


### PR DESCRIPTION
It cannot be added to pyproject.toml, otherwise it raises issues when uploading to pypi.
