### PR TITLE
Correct extra token, start preparing docker image for TGI/Jetstream Pt

### DIFF
--- a/text-generation-inference/docker/Dockerfile
+++ b/text-generation-inference/docker/Dockerfile
@@ -109,7 +109,10 @@ COPY . /opt/optimum-tpu
 
 # Install requirements for optimum-tpu, then for TGI then optimum-tpu
 RUN python3 -m pip install hf_transfer safetensors==${SAFETENSORS_VERSION} && \
-    python3 -m pip install -e /opt/optimum-tpu -f https://storage.googleapis.com/libtpu-releases/index.html
+    python3 -m pip install -e /opt/optimum-tpu[jetstream-pt] \
+        -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
+        -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html \
+        -f https://storage.googleapis.com/libtpu-releases/index.html
 
 # Install router
 COPY --from=builder /usr/src/target/release/text-generation-router /usr/local/bin/text-generation-router

--- a/text-generation-inference/server/text_generation_server/jetstream_pt_support/engine_loader.py
+++ b/text-generation-inference/server/text_generation_server/jetstream_pt_support/engine_loader.py
@@ -144,6 +144,10 @@ def create_engine(
 
     env = JetEngineEnvironment(env_data)
     model = instantiate_model_from_repo_id(model_path, env)
+    # Update config with engine data
+    model.config.batch_size = batch_size
+    model.config.sequence_length = sequence_length
+
     weight_shardings = model.get_sharding_annotations()
     sharded_weights = shard_weights(env, model.state_dict(), weight_shardings)
 

--- a/text-generation-inference/server/text_generation_server/jetstream_pt_support/generator.py
+++ b/text-generation-inference/server/text_generation_server/jetstream_pt_support/generator.py
@@ -532,7 +532,7 @@ class TpuGeneratorJetStream(Generator):
             # Get the next token.
             # Note that for now we ignore is_valid and length as we don't use them, we will re-parse these in post
             # generation.
-            next_token, _is_valid, _length = result_tokens.data[slot.id]
+            next_token = self.decode_state.tokens[slot.id].item()
 
             if slot.state != Slot.State.READY:
                 logger.error(f"Unexpected Slot {slot.id} is not ready for decoding, skipping.")

--- a/text-generation-inference/server/text_generation_server/jetstream_pt_support/generator.py
+++ b/text-generation-inference/server/text_generation_server/jetstream_pt_support/generator.py
@@ -79,6 +79,7 @@ class Slot:
         self._generated_text = ""
         self._next_text = ""
         self._truncate = 0
+        self._seed = 0
 
     @property
     def id(self) -> int:
@@ -135,7 +136,7 @@ class Slot:
         self._generation_config.do_sample = request.parameters.do_sample
         self._generation_config.repetition_penalty = request.parameters.repetition_penalty
         self._truncate = request.truncate
-        self.seed = request.parameters.seed
+        self._seed = request.parameters.seed
         # TODO: watermark
         self._generation_config.max_new_tokens = request.stopping_parameters.max_new_tokens
         self._max_new_tokens = self._generation_config.max_new_tokens
@@ -237,6 +238,10 @@ class Slot:
     @property
     def empty(self) -> bool:
         return len(self._tokens) == 0
+
+    @property
+    def seed(self) -> int:
+        return self._seed
 
 
 class TpuGeneratorJetStream(Generator):

--- a/text-generation-inference/server/text_generation_server/jetstream_pt_support/generator.py
+++ b/text-generation-inference/server/text_generation_server/jetstream_pt_support/generator.py
@@ -476,6 +476,7 @@ class TpuGeneratorJetStream(Generator):
                 self.slots.append(slot)
                 len_active_slots += 1
 
+        batch = None
         if len_active_slots > 0:
             # Whatever initial batch these requests came from, we always return all pending requests in a single batch
             request_ids = [slot.request_id for slot in self.slots if slot.state == Slot.State.READY]

--- a/text-generation-inference/server/text_generation_server/jetstream_pt_support/generator.py
+++ b/text-generation-inference/server/text_generation_server/jetstream_pt_support/generator.py
@@ -501,6 +501,13 @@ class TpuGeneratorJetStream(Generator):
         Return:
             A list of `Generation` for each request and a `CachedBatch` containing all pending requests.
         """
+
+        # In python we should use type duck, but if elements passed on the list are not of the right type, this will
+        # prevent raising an error and wasting time. Return an empty generation instead.
+        if any(not isinstance(item, CachedBatch) for item in batches):
+            logger.error("Unexpected type in decode, expected CachedBatch")
+            return [], None
+
         # batches contains a list composed of ongoing requests:
         # - the batch id returned by the last decode,
         # - the batch id(s) returned by the last prefill(s)

--- a/text-generation-inference/server/text_generation_server/jetstream_pt_support/token_selector.py
+++ b/text-generation-inference/server/text_generation_server/jetstream_pt_support/token_selector.py
@@ -55,6 +55,8 @@ class TokenSelector:
         self.eos_token_ids = eos_token_ids
         self.pad_token_id = pad_token_id
         self.logits_warper = logits_warper
+        # Seed needs to fit a 64-bit integer, so we modulo it in case is bigger (that can happen!)
+        seed = seed % jnp.iinfo(jnp.int64).max
         self.key = jax.random.PRNGKey(seed)
 
     @classmethod

--- a/text-generation-inference/tests/test_decode.py
+++ b/text-generation-inference/tests/test_decode.py
@@ -100,12 +100,12 @@ def _test_decode_single(params):
         DecodeTestParams(
             model_id="meta-llama/Llama-2-7b-hf",
             sequence_length=256,
-            expected_text="\n\nThe clocks were striking thirteen\nThe clocks were striking thirteen\n",
+            expected_text="\nThe clocks were striking thirteen\nThe clocks were striking thirteen\nThe",
         ),
         DecodeTestParams(
             model_id="meta-llama/Meta-Llama-3-8B",
             sequence_length=256,
-            expected_text=" Winston Winston Smith, his chin on his hands, and the clock in the Ministry of Truth, M",
+            expected_text=" Winston Smith, his chin on his hands, and the clock in the Ministry of Truth, Minit",
         ),
     ],
     ids=["Llama-2-7b-hf", "Meta-Llama-3-8B"],
@@ -123,7 +123,7 @@ def test_decode_single_jetstream_pytorch_slow(params, do_sample):
         DecodeTestParams(
             model_id="Maykeye/TinyLLama-v0",
             sequence_length=256,
-            expected_text=" She She had a big and it had a big, blue, and a big, red and a",
+            expected_text=" She had a big and it had a big, blue, and a big, red and a big",
         ),
     ],
     ids=["TinyLLama-v0"],

--- a/text-generation-inference/tests/test_warmup.py
+++ b/text-generation-inference/tests/test_warmup.py
@@ -1,0 +1,30 @@
+
+
+import pytest
+from helpers import create_request, prepare_model
+from text_generation_server.auto_generator import AutoGenerator
+from text_generation_server.pb.generate_pb2 import Batch
+
+from optimum.tpu.jetstream_pt_support import jetstream_pt_available
+
+
+def test_warmup_jetstream_pytorch():
+    if not jetstream_pt_available():
+        pytest.skip("Jetstream PyTorch is not available")
+    model_id = "Maykeye/TinyLLama-v0"
+
+    # The maximum sequence length of the model is set to 1000, but warmup will round that up to the next power of two
+    # in prefill (1024).
+    sequence_length = 1000
+
+    model_path = prepare_model(model_id, sequence_length)
+    input_text = "It was a bright cold day in April, and the clocks were striking thirteen."
+    max_new_tokens = 20
+
+    generator = AutoGenerator.from_pretrained(
+        model_path, revision="", max_batch_size=1, max_sequence_length=sequence_length
+    )
+    request = create_request(id=0, inputs=input_text, max_new_tokens=max_new_tokens, do_sample=False)
+    batch = Batch(id=0, requests=[request], size=1, max_tokens=sequence_length)
+    generator.warmup(batch)
+


### PR DESCRIPTION
# What does this PR do?

There was an issue related to the fact that decode used to return the token passed in the decode state as result, making TGI see as if the first token was returned twice. This is resolved by using the data in the decode state (the API should be stable, according to internal discussions with the Jetstream Pytorch team).
Also, the docker image is now capable of serving TGI using Jetstream Pytorch on the supported models.


## Before submitting
- [x] Did you write any new necessary tests?
