### PR TITLE
Fix slow tests

### DIFF
--- a/.github/workflows/test-pytorch-xla-tpu-tgi-nightly.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-nightly.yml
@@ -41,9 +41,6 @@ jobs:
       # Use a different step to test the Jetstream Pytorch version, to avoid conflicts with torch-xla[tpu]
       - name: Install and test TGI server slow tests (Jetstream Pytorch)
         run: |
-          pip install -U .[jetstream-pt] \
-            -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
-            -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html \
-            -f https://storage.googleapis.com/libtpu-releases/index.html
+          make jetstream_requirements
           JETSTREAM_PT=1 HF_TOKEN=${{ secrets.HF_TOKEN_OPTIMUM_TPU_CI }} python -m \
             pytest -sv text-generation-inference/tests --runslow -k jetstream

--- a/optimum/tpu/model.py
+++ b/optimum/tpu/model.py
@@ -49,7 +49,7 @@ def fetch_model(
     local_path = snapshot_download(
         repo_id=model_id,
         revision=revision,
-        allow_patterns=["*.json", "model*.safetensors", SAFE_WEIGHTS_INDEX_NAME],
+        allow_patterns=["*.json", "model*.safetensors", SAFE_WEIGHTS_INDEX_NAME, "tokenizer.*"],
     )
     end = time.time()
     logger.info(f"Model successfully fetched in {end - start:.2f} s.")


### PR DESCRIPTION
# What does this PR do?

Slow tests have been failing for a while, this should fix them:

- [x] For Mistral, a required file for the tokenizer was not downloaded anymore, this should be fixed.
- [x] Jetstream slow tests were not even run, and installation will now be done with the new `make jetstream_requirements` command.
