### PR TITLE
Small TGI enhancements

### DIFF
--- a/text-generation-inference/server/text_generation_server/auto_generator.py
+++ b/text-generation-inference/server/text_generation_server/auto_generator.py
@@ -8,7 +8,7 @@ class AutoGenerator:
 
     @staticmethod
     def from_pretrained(
-        model_path: str, revision: str, max_batch_size: int, max_sequence_length: int
+        model_path: str, revision: str, max_batch_size: int, max_sequence_length: int, max_input_tokens: int = None
     ) -> Generator:
         """Instantiate a Generator for TPU using Jetstream Pytorch or Pytorch/XLA.
 
@@ -21,15 +21,24 @@ class AutoGenerator:
                 The maximum batch size.
             max_sequence_length (`int`):
                 The maximum sequence length.
+            max_input_tokens (`int`):
+                The maximum number of tokens allowed in the input. When set to None, it will be set to 80% of the
+                `max_sequence_length`.
 
         Returns:
             A TpuGenerator.
         """
+        if max_input_tokens is None:
+            max_input_tokens = int(0.8 * max_sequence_length)
         if model_can_use_jetstream_pt(model_path):
             logger.debug("Using Jetstream PyTorch generator.")
             from .jetstream_pt_support.generator import TpuGeneratorJetStream
             return TpuGeneratorJetStream.from_pretrained(
-                model_path, revision=revision, max_batch_size=max_batch_size, max_sequence_length=max_sequence_length
+                model_path,
+                revision=revision,
+                max_batch_size=max_batch_size,
+                max_sequence_length=max_sequence_length,
+                max_input_tokens=max_input_tokens,
             )
         else:
             logger.debug("Using PyTorch/XLA generator.")

--- a/text-generation-inference/server/text_generation_server/cli.py
+++ b/text-generation-inference/server/text_generation_server/cli.py
@@ -64,7 +64,6 @@ def serve(
     # TODO: these two parameters are used when the server is started, but they are not used yet, so just inform the
     # user about that.
     logger.info("'otlp_service_name' argument is not supported and will be ignored.")
-    logger.info("'max_input_tokens' argument is not supported and will be ignored.")
 
     # This is a workaround to pass the logger level to other threads, it's only used in 
     # Pytorch/XLA generator.
@@ -86,6 +85,7 @@ def serve(
         revision=revision,
         max_batch_size=max_batch_size,
         max_sequence_length=max_total_tokens,
+        max_input_tokens=max_input_tokens,
         uds_path=uds_path
     )
 

--- a/text-generation-inference/server/text_generation_server/cli.py
+++ b/text-generation-inference/server/text_generation_server/cli.py
@@ -65,7 +65,7 @@ def serve(
     # user about that.
     logger.info("'otlp_service_name' argument is not supported and will be ignored.")
 
-    # This is a workaround to pass the logger level to other threads, it's only used in 
+    # This is a workaround to pass the logger level to other threads, it's only used in
     # Pytorch/XLA generator.
     os.environ["LOGGER_LEVEL_GENERATOR"] = logger_level
 

--- a/text-generation-inference/server/text_generation_server/generator.py
+++ b/text-generation-inference/server/text_generation_server/generator.py
@@ -399,6 +399,9 @@ class TpuGeneratorSingleThread(Generator):
         # Counter-intuitively, now we ignore the input batch. Instead, we create dummy batches to cover all possible
         # batch sizes and sequence lengths.
         seq_len = self.model.config.sequence_length
+        if os.environ.get("SKIP_WARMUP", "0") == "1":
+            logger.debug("Skipping warmup")
+            return batch_size * seq_len
         bucket_seq_len = take_nearest_length(seq_len)
         requests = [self._create_dummy_request(seq_len) for _ in range(batch_size)]
         for _ in reversed(range(batch_size)):

--- a/text-generation-inference/server/text_generation_server/jetstream_pt_support/engine_loader.py
+++ b/text-generation-inference/server/text_generation_server/jetstream_pt_support/engine_loader.py
@@ -61,6 +61,7 @@ def create_engine_env_data(
     shard_on_batch = False
     max_cache_length = max_input_tokens + max_output_tokens
 
+    logger.info(f"Creating engine with max_cache_length={max_cache_length} = {max_input_tokens} + {max_output_tokens}")
     env_data = JetEngineEnvironmentData(
         tokenizer_path="", # Tokenizer is not user, HF tokenizer is used instead
         checkpoint_path=model_path,

--- a/text-generation-inference/server/text_generation_server/server.py
+++ b/text-generation-inference/server/text_generation_server/server.py
@@ -65,6 +65,7 @@ def serve(
     revision: str,
     max_batch_size: int,
     max_sequence_length: int,
+    max_input_tokens: int,
     uds_path: Path,
 ):
     async def serve_inner(model_path: str):
@@ -77,7 +78,8 @@ def serve(
                 model_path,
                 revision=revision,
                 max_batch_size=max_batch_size,
-                max_sequence_length=max_sequence_length
+                max_sequence_length=max_sequence_length,
+                max_input_tokens=max_input_tokens,
             )
         except Exception:
             logger.exception("Error when initializing model")

--- a/text-generation-inference/tests/test_warmup.py
+++ b/text-generation-inference/tests/test_warmup.py
@@ -14,10 +14,7 @@ def test_warmup_jetstream_pytorch():
     if not jetstream_pt_available():
         pytest.skip("Jetstream PyTorch is not available")
     model_id = "Maykeye/TinyLLama-v0"
-
-    # The maximum sequence length of the model is set to 1000, but warmup will round that up to the next power of two
-    # in prefill (256).
-    sequence_length = 250
+    sequence_length = 256
 
     model_path = prepare_model(model_id, sequence_length)
     input_text = "It was a bright cold day in April, and the clocks were striking thirteen."
@@ -27,7 +24,10 @@ def test_warmup_jetstream_pytorch():
         model_path, revision="", max_batch_size=2, max_sequence_length=sequence_length
     )
     request = create_request(id=0, inputs=input_text, max_new_tokens=max_new_tokens, do_sample=False)
-    batch = Batch(id=0, requests=[request], size=1, max_tokens=sequence_length)
+    # The maximum sequence length of the model is set to 1000, but warmup will round that up to the next power of two
+    # in prefill (256).
+    max_tokens = 250
+    batch = Batch(id=0, requests=[request], size=1, max_tokens=max_tokens)
     generator.warmup(batch)
 
     # Prepare a new request with different settings. Warmup should have triggered compilation so this can be run


### PR DESCRIPTION
# What does this PR do?

- Handle `max_input_tokens` sever argument, that can reduce the cache size in Jetstream.
- Add `SKIP_WARMUP` parameter to the legacy Pytorch/XLA TGI to simply debug.