### PR TITLE
fix(TGI Jetstream Pt): prefill should be done with max input size

### DIFF
--- a/text-generation-inference/server/text_generation_server/jetstream_pt_support/generator.py
+++ b/text-generation-inference/server/text_generation_server/jetstream_pt_support/generator.py
@@ -334,7 +334,7 @@ class TpuGeneratorJetStream(Generator):
         if os.environ.get("SKIP_WARMUP", "0") == "1":
             logger.debug("Skipping warmup")
             return batch_size * seq_len
-        bucket_seq_len = take_nearest_length(DEFAULT_PREFILL_BUCKETS, seq_len)
+        bucket_seq_len = take_nearest_length(DEFAULT_PREFILL_BUCKETS, self.engine.max_prefill_length)
         decode_done = False
         for l in reversed(DEFAULT_PREFILL_BUCKETS):
             # Skip all the unsupported lengths


### PR DESCRIPTION
# What does this PR do?

Previously it was attempting to use the sequence length, leading to larger allocation and useless graph compilations.

