### PR TITLE
⛰ CI: mount hub cache and fix issues with cli

### DIFF
--- a/.github/workflows/test-pytorch-xla-tpu-tgi-jetstream.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-jetstream.yml
@@ -19,9 +19,10 @@ jobs:
       group: gcp-ct5lp-hightpu-8t
     container:
       image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:r2.4.0_3.10_tpuvm
-      options: --shm-size "16gb" --ipc host --privileged ${{ vars.V5_LITEPOD_8_ENV}}
+      options: --shm-size "16gb" --ipc host --privileged ${{ vars.V5_LITEPOD_8_ENV}} -v /mnt/hf_cache:/mnt/hf_cache
     env:
       PJRT_DEVICE: TPU
+      HF_HUB_CACHE: /mnt/hf_cache/cache_huggingface
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-pytorch-xla-tpu-tgi-nightly-jetstream.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-nightly-jetstream.yml
@@ -1,9 +1,6 @@
 name: Optimum TPU / Test TGI on TPU (slow tests) / Jetstream Pytorch
 
 on:
-  push:
-    branches: [ main ]
-  # This can be used to automatically publish nightlies at UTC nighttime
   schedule:
   - cron: '0 3 * * *' # run at 3 AM UTC
   # This can be used to allow manually triggering nightlies from the web interface

--- a/.github/workflows/test-pytorch-xla-tpu-tgi-nightly-jetstream.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-nightly-jetstream.yml
@@ -20,10 +20,11 @@ jobs:
       group: gcp-ct5lp-hightpu-8t
     container:
       image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:r2.4.0_3.10_tpuvm
-      options: --shm-size "16gb" --ipc host --privileged ${{ vars.V5_LITEPOD_8_ENV}}
+      options: --shm-size "16gb" --ipc host --privileged ${{ vars.V5_LITEPOD_8_ENV}} -v /mnt/hf_cache:/mnt/hf_cache
     env:
       PJRT_DEVICE: TPU
       HF_TOKEN: ${{ secrets.HF_TOKEN_OPTIMUM_TPU_CI }}
+      HF_HUB_CACHE: /mnt/hf_cache/cache_huggingface
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,13 +35,13 @@ jobs:
           find text-generation-inference/ -name "text_generation_server-*whl" -exec python -m pip install {} \;
       - name: Run TGI Jetstream Pytorch - Llama
         run: |
-          JETSTREAM_PT=1 HF_TOKEN=${{ secrets.HF_TOKEN_OPTIMUM_TPU_CI }} python -m \
+          JETSTREAM_PT=1 python -m \
             pytest -sv text-generation-inference/tests --runslow -k "jetstream and slow and Llama"
       - name: Run TGI Jetstream Pytorch - Gemma
         run: |
-          JETSTREAM_PT=1 HF_TOKEN=${{ secrets.HF_TOKEN_OPTIMUM_TPU_CI }} python -m \
+          JETSTREAM_PT=1 python -m \
             pytest -sv text-generation-inference/tests --runslow -k "jetstream and slow and gemma"
       - name: Run TGI Jetstream Pytorch - Mixtral greedy
         run: |
-          JETSTREAM_PT=1 HF_TOKEN=${{ secrets.HF_TOKEN_OPTIMUM_TPU_CI }} python -m \
+          JETSTREAM_PT=1 python -m \
             pytest -sv text-generation-inference/tests --runslow -k "jetstream and slow and Mixtral and greedy"

--- a/.github/workflows/test-pytorch-xla-tpu-tgi-nightly.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-nightly.yml
@@ -18,10 +18,11 @@ jobs:
       group: gcp-ct5lp-hightpu-8t
     container:
       image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:r2.4.0_3.10_tpuvm
-      options: --shm-size "16gb" --ipc host --privileged ${{ vars.V5_LITEPOD_8_ENV}}
+      options: --shm-size "16gb" --ipc host --privileged ${{ vars.V5_LITEPOD_8_ENV}} -v /mnt/hf_cache:/mnt/hf_cache
     env:
       PJRT_DEVICE: TPU
       HF_TOKEN: ${{ secrets.HF_TOKEN_OPTIMUM_TPU_CI }}
+      HF_HUB_CACHE: /mnt/hf_cache/cache_huggingface
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-pytorch-xla-tpu-tgi.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi.yml
@@ -21,9 +21,10 @@ jobs:
       group: gcp-ct5lp-hightpu-8t
     container:
       image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:r2.4.0_3.10_tpuvm
-      options: --shm-size "16gb" --ipc host --privileged ${{ vars.V5_LITEPOD_8_ENV}}
+      options: --shm-size "16gb" --ipc host --privileged ${{ vars.V5_LITEPOD_8_ENV}} -v /mnt/hf_cache:/mnt/hf_cache
     env:
       PJRT_DEVICE: TPU
+      HF_HUB_CACHE: /mnt/hf_cache/cache_huggingface
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-pytorch-xla-tpu.yml
+++ b/.github/workflows/test-pytorch-xla-tpu.yml
@@ -21,9 +21,10 @@ jobs:
       group: gcp-ct5lp-hightpu-8t
     container:
       image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:r2.4.0_3.10_tpuvm
-      options: --shm-size "16gb" --ipc host --privileged ${{ vars.V5_LITEPOD_8_ENV}}
+      options: --shm-size "16gb" --ipc host --privileged ${{ vars.V5_LITEPOD_8_ENV}} -v /mnt/hf_cache:/mnt/hf_cache
     env:
       PJRT_DEVICE: TPU
+      HF_HUB_CACHE: /mnt/hf_cache/cache_huggingface
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,8 @@ tgi_server:
 	make -C text-generation-inference/server clean
 	VERSION=${VERSION} TGI_VERSION=${TGI_VERSION} make -C text-generation-inference/server gen-server
 
-jetstream_requirements:
-	python optimum/tpu/cli.py install-jetstream-pt --force
+jetstream_requirements: test_installs
+	python optimum/tpu/cli.py install-jetstream-pytorch --yes
 
 tgi_test_jetstream: test_installs jetstream_requirements tgi_server
 	find text-generation-inference -name "text_generation_server-$(VERSION)-py3-none-any.whl" \


### PR DESCRIPTION
# What does this PR do?

Mount Hub cache and fix CLI errors. This should have two consequences:
- Increased speed in testing, because models do not need to be downloaded each time,
- Increased available space, that could be otherwise saturated (that I suspect being the reason why the nightly tests have been failing lately).