### PR TITLE
TPU v4 install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ We currently support a few LLM models targeting text generation scenarios:
 
 ## Installation
 
+For installation on a TPU v4, use the `install-on-TPU-v4.sh` script. Make sure that you DO NOT install pallas or Jetstream as both are targeting TPU v5e!
+
+Via package:
 `optimum-tpu` comes with an handy PyPi released package compatible with your classical python dependency management tool.
 
 `pip install optimum-tpu -f https://storage.googleapis.com/libtpu-releases/index.html`

--- a/install-on-TPU-v4.sh
+++ b/install-on-TPU-v4.sh
@@ -1,0 +1,24 @@
+sudo apt remove unattended-upgrades
+sudo apt update
+export PJRT_DEVICE=TPU
+export PATH="/home/artuskg/.local/bin:$PATH"
+pip install build
+pip install --upgrade setuptools
+sudo apt install python3.10-venv
+
+git clone https://github.com/huggingface/optimum-tpu.git
+
+cd optimum-tpu
+make
+make build_dist_install_tools
+make build_dist
+
+python -m venv optimum_tpu_env
+source optimum_tpu_env/bin/activate
+
+pip install torch==2.4.0 torch_xla[tpu]==2.4.0 torchvision -f https://storage.googleapis.com/libtpu-releases/index.html
+pip uninstall torchvision # it might insist von 2.4.1
+pip install -e .
+
+huggingface-cli login
+gsutil cp -r gs://entropix/huggingface_hub ~/.cache/huggingface/hub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,11 @@ tests = ["pytest", "safetensors"]
 quality = ["black", "ruff", "isort"]
 # Jetstream/Pytorch support is experimental for now, it needs to be installed manually.
 # Pallas is pulled because it will install a compatible version of jax[tpu].
-jetstream-pt = [
-    "jetstream-pt",
-    "torch-xla[pallas] == 2.4.0"
-]
+# pallas and jetstream are not supported before v5e. Therefore, comment out on v4 and earlier
+#jetstream-pt = [
+#    "jetstream-pt",
+#    "torch-xla[pallas] == 2.4.0"
+#]
 
 [project.urls]
 Homepage = "https://hf.co/hardware"


### PR DESCRIPTION
# This PR validates that it is possible to use optimum-tpu on older GCP TPUs, especially on the TPU v4 generation.

Originally, this repository is targeting TPU v5e. However, there is still both an existing large installed based for older TPU generations and, importantly, the TPU Research Council grants only encompass the older generations v2, v3, and v4 but no v5 and newer. Therefore, I wanted to ascertain that also on TPU v4 optimum-tpu can be used to accelerate research via huggingface. 

Essentially, I have provided a validated and tested install plus the deactivation of pallas and Jetstream, which only target TPU v5.

Note that the install script is still intended to be run by hand although full automation should be straightforward.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
