### PR TITLE
Quantization Jetstream Pytorch

### DIFF
--- a/.github/workflows/test-pytorch-xla-tpu-tgi-nightly-jetstream.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-nightly-jetstream.yml
@@ -22,6 +22,7 @@ jobs:
       PJRT_DEVICE: TPU
       HF_TOKEN: ${{ secrets.HF_TOKEN_OPTIMUM_TPU_CI }}
       HF_HUB_CACHE: /mnt/hf_cache/cache_huggingface
+      JETSTREAM_PT: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,13 +33,29 @@ jobs:
           find text-generation-inference/ -name "text_generation_server-*whl" -exec python -m pip install {} \;
       - name: Run TGI Jetstream Pytorch - Llama
         run: |
-          JETSTREAM_PT=1 python -m \
-            pytest -sv text-generation-inference/tests --runslow -k "jetstream and slow and Llama"
+          python -m \
+            pytest -sv text-generation-inference/tests/test_decode_jetstream.py --runslow -k "slow and Llama"
       - name: Run TGI Jetstream Pytorch - Gemma
         run: |
-          JETSTREAM_PT=1 python -m \
-            pytest -sv text-generation-inference/tests --runslow -k "jetstream and slow and gemma"
+          python -m \
+            pytest -sv text-generation-inference/tests/test_decode_jetstream.py --runslow -k "slow and gemma"
       - name: Run TGI Jetstream Pytorch - Mixtral greedy
         run: |
-          JETSTREAM_PT=1 python -m \
-            pytest -sv text-generation-inference/tests --runslow -k "jetstream and slow and Mixtral and greedy"
+          python -m \
+            pytest -sv text-generation-inference/tests/test_decode_jetstream.py --runslow -k "slow and Mixtral and greedy"
+      - name: Run TGI Jetstream Pytorch - Quantization Mixtral
+        run: |
+          python -m \
+            pytest -sv text-generation-inference/tests/test_decode_jetstream_quant.py --runslow -k "slow and Mixtral"
+      - name: Run TGI Jetstream Pytorch - Quantization Llama-3 8B
+        run: |
+          python -m \
+            pytest -sv text-generation-inference/tests/test_decode_jetstream_quant.py --runslow -k "slow and Llama-3-8B"
+      - name: Run TGI Jetstream Pytorch - Quantization Llama 3 70B
+        run: |
+          python -m \
+            pytest -sv text-generation-inference/tests/test_decode_jetstream_quant.py --runslow -k "slow and Llama-3-70B"
+      - name: Run TGI Jetstream Pytorch - Other tests
+        run: |
+          python -m \
+            pytest -sv text-generation-inference/tests --runslow -k "jetstream and not decode and not quant"

--- a/docs/source/howto/deploy.mdx
+++ b/docs/source/howto/deploy.mdx
@@ -47,7 +47,7 @@ gcloud alpha compute tpus tpu-vm create optimum-tpu-get-started \
 ## Connecting to the instance
 
 ```bash
-gcloud compute tpus tpu-vm ssh <ref_instance_name> --zone=<deploiment_zone>
+gcloud compute tpus tpu-vm ssh <ref_instance_name> --zone=<deployment_zone>
 $ >
 ```
 
@@ -79,4 +79,4 @@ xla:0
 
 ### Optimum-TPU with JAX
 
-JAX is coming very soon - stay tuned!
+JAX is coming soon - stay tuned!

--- a/docs/source/howto/serving.mdx
+++ b/docs/source/howto/serving.mdx
@@ -49,3 +49,11 @@ curl localhost/generate_stream \
     -d '{"inputs":"What is Deep Learning?","parameters":{"max_new_tokens":20}}' \
     -H 'Content-Type: application/json'
 ```
+
+### Using Jetstream Pytorch as backend
+
+[Jetstream Pytorch](https://github.com/AI-Hypercomputer/jetstream-pytorch) is a highly optimized Pytorch engine for serving LLMs on Cloud TPU. It is possible to use this engine by setting the `JETSTREAM_PT=1` environment variable.
+
+When using Jetstream Pytorch engine, it is possible to enable quantization to reduce the memory footprint and increase the throughput. To enable quantization, set the `QUANTIZATION=1` environment variable.
+
+***Note: Quantization is still experimental and may produce lower quality results compared to the non-quantized version.***

--- a/optimum/tpu/cli.py
+++ b/optimum/tpu/cli.py
@@ -10,7 +10,7 @@ import typer
 
 
 TORCH_VER = "2.4.0"
-JETSTREAM_PT_VER = "ec4ac8f6b180ade059a2284b8b7d843b3cab0921"
+JETSTREAM_PT_VER = "02927c9f563082421abe8eedceabe8aedd7ec2f9"
 DEFAULT_DEPS_PATH = os.path.join(Path.home(), ".jetstream-deps")
 
 app = typer.Typer()

--- a/text-generation-inference/docker/entrypoint.sh
+++ b/text-generation-inference/docker/entrypoint.sh
@@ -23,6 +23,15 @@ if [[ -z "${MODEL_ID}" ]]; then
 fi
 export MODEL_ID="${MODEL_ID}"
 
+if [[ -z "${QUANTIZATION}" ]]; then
+  QUANTIZATION=""
+else
+  QUANTIZATION="jetstream_int8"
+fi
+export QUANTIZATION="${QUANTIZATION}"
+
+
+
 text-generation-launcher --port 8080 \
   --max-batch-size ${BATCH_SIZE} \
   ${JSON_OUTPUT_DISABLE} \

--- a/text-generation-inference/tests/conftest.py
+++ b/text-generation-inference/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 
@@ -20,3 +22,14 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
+
+
+@pytest.fixture(scope="function")
+def quantization_jetstream_int8():
+    # Setup
+    old_environ = dict(os.environ)
+    os.environ["QUANTIZATION"] = "jetstream_int8"
+    yield
+    # Clean up
+    os.environ.clear()
+    os.environ.update(old_environ)

--- a/text-generation-inference/tests/decode_tests_utils.py
+++ b/text-generation-inference/tests/decode_tests_utils.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+
+from helpers import create_request, prepare_model
+from text_generation_server.auto_generator import AutoGenerator
+from text_generation_server.pb.generate_pb2 import Batch
+from tqdm import tqdm
+
+
+@dataclass
+class DecodeTestParams:
+    model_id: str
+    sequence_length: int
+    expected_text: str
+    do_sample: bool = False
+    max_new_tokens: int = 20
+    top_k: int = 50
+
+
+def decode_single_test(params):
+    model_path = prepare_model(params.model_id, params.sequence_length)
+    input_text = "It was a bright cold day in April, and the clocks were striking thirteen."
+    max_new_tokens = params.max_new_tokens
+
+    generator = AutoGenerator.from_pretrained(
+        model_path, revision="", max_batch_size=1, max_sequence_length=params.sequence_length
+    )
+    request = create_request(
+        id=0,
+        inputs=input_text,
+        max_new_tokens=max_new_tokens,
+        do_sample=params.do_sample,
+        top_k=params.top_k,
+    )
+    batch = Batch(id=0, requests=[request], size=1, max_tokens=params.sequence_length)
+    generations, next_batch = generator.prefill(batch)
+    # We already generated one token: call decode max_new_tokens - 1 times
+    for _ in tqdm(range(max_new_tokens - 1)):
+        assert next_batch.size == 1
+        assert next_batch.max_tokens == params.sequence_length
+        assert len(generations) == 1
+        assert len(generations[0].tokens.ids) == 1
+        generations, next_batch = generator.decode([next_batch])
+    # Destroy generator: this will properly stop threads and prevent them from getting stuck if one of the following
+    # assertions fails.
+    del generator
+    assert next_batch is None
+    assert len(generations) == 1
+    output = generations[0].generated_text
+    assert output.generated_tokens == max_new_tokens
+    assert output.finish_reason == 0
+    print(f"Generated text: {output.text}")
+    if params.do_sample:
+        assert output.text != params.expected_text
+    else:
+        assert output.text == params.expected_text

--- a/text-generation-inference/tests/test_decode.py
+++ b/text-generation-inference/tests/test_decode.py
@@ -1,22 +1,6 @@
-from dataclasses import dataclass
 
 import pytest
-from helpers import create_request, prepare_model
-from text_generation_server.auto_generator import AutoGenerator
-from text_generation_server.pb.generate_pb2 import Batch
-from tqdm import tqdm
-
-from optimum.tpu.jetstream_pt_support import jetstream_pt_available
-
-
-@dataclass
-class DecodeTestParams:
-    model_id: str
-    sequence_length: int
-    expected_text: str
-    do_sample: bool = False
-    max_new_tokens: int = 20
-    top_k: int = 50
+from decode_tests_utils import DecodeTestParams, decode_single_test
 
 
 @pytest.mark.parametrize("params",
@@ -35,7 +19,7 @@ class DecodeTestParams:
     ids=["gemma-2b", "TinyLLama-v0"],
 )
 def test_decode_single(params):
-    _test_decode_single(params)
+    decode_single_test(params)
 
 @pytest.mark.slow
 @pytest.mark.parametrize("params",
@@ -59,157 +43,4 @@ def test_decode_single(params):
     ids=["Meta-Llama-3-8B", "gemma-7b", "Mistral-7B-v0.3"],
 )
 def test_decode_single_slow(params):
-    _test_decode_single(params)
-
-
-def _test_decode_single(params):
-    model_path = prepare_model(params.model_id, params.sequence_length)
-    input_text = "It was a bright cold day in April, and the clocks were striking thirteen."
-    max_new_tokens = params.max_new_tokens
-
-    generator = AutoGenerator.from_pretrained(
-        model_path, revision="", max_batch_size=1, max_sequence_length=params.sequence_length
-    )
-    request = create_request(
-        id=0,
-        inputs=input_text,
-        max_new_tokens=max_new_tokens,
-        do_sample=params.do_sample,
-        top_k=params.top_k,
-    )
-    batch = Batch(id=0, requests=[request], size=1, max_tokens=params.sequence_length)
-    generations, next_batch = generator.prefill(batch)
-    # We already generated one token: call decode max_new_tokens - 1 times
-    for _ in tqdm(range(max_new_tokens - 1)):
-        assert next_batch.size == 1
-        assert next_batch.max_tokens == params.sequence_length
-        assert len(generations) == 1
-        assert len(generations[0].tokens.ids) == 1
-        generations, next_batch = generator.decode([next_batch])
-    # Destroy generator: this will properly stop threads and prevent them from getting stuck if one of the following
-    # assertions fails.
-    del generator
-    assert next_batch is None
-    assert len(generations) == 1
-    output = generations[0].generated_text
-    assert output.generated_tokens == max_new_tokens
-    assert output.finish_reason == 0
-    print(f"Generated text: {output.text}")
-    if params.do_sample:
-        assert output.text != params.expected_text
-    else:
-        assert output.text == params.expected_text
-
-
-@pytest.mark.slow
-@pytest.mark.parametrize("do_sample", [False, True], ids=["greedy", "sample"])
-@pytest.mark.parametrize("params",
-    [
-        DecodeTestParams(
-            model_id="meta-llama/Llama-2-7b-hf",
-            sequence_length=256,
-            expected_text="\nWinston Smith, his chin nuzzled into his breast in an effort to escape",
-            top_k=100,
-        ),
-        DecodeTestParams(
-            model_id="meta-llama/Meta-Llama-3-8B",
-            sequence_length=256,
-            expected_text=" Winston Smith, his chin nuzzled into his breast in an effort to escape the vile wind,",
-            top_k=100,
-        ),
-        DecodeTestParams(
-            model_id="google/gemma-7b",
-            sequence_length=128,
-            expected_text="\n\nThe time is 1984. The place is Airstrip One, the British",
-        ),
-        DecodeTestParams(
-            model_id="mistralai/Mixtral-8x7B-v0.1",
-            sequence_length=1024,
-            expected_text="\n\nGeorge Orwell, 1984\n\nThe clocks are striking thirteen",
-        ),
-    ],
-    ids=["Llama-2-7b-hf", "Meta-Llama-3-8B", "gemma-7b", "Mixtral-8x7B"],
-)
-def test_decode_single_jetstream_pytorch_slow(params, do_sample):
-    if not jetstream_pt_available():
-        pytest.skip("Jetstream PyTorch is not available")
-    params.do_sample = do_sample
-    _test_decode_single(params)
-
-
-@pytest.mark.parametrize("do_sample", [False, True], ids=["greedy", "sample"])
-@pytest.mark.parametrize("params",
-    [
-        DecodeTestParams(
-            model_id="Maykeye/TinyLLama-v0",
-            sequence_length=256,
-            expected_text=" The sun was shining and the sky was shining.\nSuddenly, a big wind came and blew the wind away.",
-            max_new_tokens=25,
-        ),
-        DecodeTestParams(
-            model_id="google/gemma-2b",
-            sequence_length=1024,
-            expected_text="\n\nThe first thing I noticed was the smell of the rain. It was a smell I had never",
-        ),
-        DecodeTestParams(
-            model_id="dacorvo/Mixtral-tiny", # This is a random tiny model, just to test model can be loaded.
-            sequence_length=512,
-            expected_text="манaminationVariableßer Rog malesazine longふ Toy Champions enero Facereverse▲verbose prosecut literally disappearedअ",
-        ),
-    ],
-    ids=["TinyLLama-v0", "gemma-2b", "Mixtral-tiny"],
-)
-def test_decode_single_jetstream_pytorch(params, do_sample):
-    if not jetstream_pt_available():
-        pytest.skip("Jetstream PyTorch is not available")
-    params.do_sample = do_sample
-    _test_decode_single(params)
-
-
-@pytest.mark.parametrize("params",
-    [
-        DecodeTestParams(
-            model_id="google/gemma-2b",
-            sequence_length=1024,
-            expected_text="\n\nThe first thing I noticed was the smell of the rain. It was a very heavy rain,",
-        ),
-        DecodeTestParams(
-            model_id="Maykeye/TinyLLama-v0",
-            sequence_length=256,
-            expected_text=" It was a very special day, and it was a very special day.\nThe mommy said to her, \"Let",
-            max_new_tokens=25,
-        ),
-    ],
-    ids=["gemma-2b", "TinyLLama-v0"],
-)
-def test_decode_jetstream_quantization(quantization_jetstream_int8, params):
-    if not jetstream_pt_available():
-        pytest.skip("Jetstream PyTorch is not available")
-    _test_decode_single(params)
-
-
-@pytest.mark.slow
-@pytest.mark.parametrize("params",
-    [
-        DecodeTestParams(
-            model_id="mistralai/Mixtral-8x7B-v0.1",
-            sequence_length=1024,
-            expected_text="\n\nGeorge Orwell, 1984\n\nThe clocks are striking thirteen",
-        ),
-        DecodeTestParams(
-            model_id="meta-llama/Meta-Llama-3-8B",
-            sequence_length=256,
-            expected_text=" Winston Smith, his chin nuzzled into his breast in an effort to escape the vile wind,",
-        ),
-        DecodeTestParams(
-            model_id="meta-llama/Meta-Llama-3-70B",
-            sequence_length=512,
-            expected_text=" Winston Smith,s,s,s,s,s,s,s,s,s,s",
-        ),
-    ],
-    ids=["Mixtral-8x7B", "Meta-Llama-3-8B" ,"Meta-Llama-3-70B"],
-)
-def test_decode_jetstream_quantization_slow(quantization_jetstream_int8, params):
-    if not jetstream_pt_available():
-        pytest.skip("Jetstream PyTorch is not available")
-    _test_decode_single(params)
+    decode_single_test(params)

--- a/text-generation-inference/tests/test_decode.py
+++ b/text-generation-inference/tests/test_decode.py
@@ -164,3 +164,52 @@ def test_decode_single_jetstream_pytorch(params, do_sample):
         pytest.skip("Jetstream PyTorch is not available")
     params.do_sample = do_sample
     _test_decode_single(params)
+
+
+@pytest.mark.parametrize("params",
+    [
+        DecodeTestParams(
+            model_id="google/gemma-2b",
+            sequence_length=1024,
+            expected_text="\n\nThe first thing I noticed was the smell of the rain. It was a very heavy rain,",
+        ),
+        DecodeTestParams(
+            model_id="Maykeye/TinyLLama-v0",
+            sequence_length=256,
+            expected_text=" It was a very special day, and it was a very special day.\nThe mommy said to her, \"Let",
+            max_new_tokens=25,
+        ),
+    ],
+    ids=["gemma-2b", "TinyLLama-v0"],
+)
+def test_decode_jetstream_quantization(quantization_jetstream_int8, params):
+    if not jetstream_pt_available():
+        pytest.skip("Jetstream PyTorch is not available")
+    _test_decode_single(params)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("params",
+    [
+        DecodeTestParams(
+            model_id="mistralai/Mixtral-8x7B-v0.1",
+            sequence_length=1024,
+            expected_text="\n\nGeorge Orwell, 1984\n\nThe clocks are striking thirteen",
+        ),
+        DecodeTestParams(
+            model_id="meta-llama/Meta-Llama-3-8B",
+            sequence_length=256,
+            expected_text=" Winston Smith, his chin nuzzled into his breast in an effort to escape the vile wind,",
+        ),
+        DecodeTestParams(
+            model_id="meta-llama/Meta-Llama-3-70B",
+            sequence_length=512,
+            expected_text=" Winston Smith,s,s,s,s,s,s,s,s,s,s",
+        ),
+    ],
+    ids=["Mixtral-8x7B", "Meta-Llama-3-8B" ,"Meta-Llama-3-70B"],
+)
+def test_decode_jetstream_quantization_slow(quantization_jetstream_int8, params):
+    if not jetstream_pt_available():
+        pytest.skip("Jetstream PyTorch is not available")
+    _test_decode_single(params)

--- a/text-generation-inference/tests/test_decode_jetstream.py
+++ b/text-generation-inference/tests/test_decode_jetstream.py
@@ -1,0 +1,70 @@
+
+import pytest
+from decode_tests_utils import DecodeTestParams, decode_single_test
+
+from optimum.tpu.jetstream_pt_support import jetstream_pt_available
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("do_sample", [False, True], ids=["greedy", "sample"])
+@pytest.mark.parametrize("params",
+    [
+        DecodeTestParams(
+            model_id="meta-llama/Llama-2-7b-hf",
+            sequence_length=256,
+            expected_text="\nWinston Smith, his chin nuzzled into his breast in an effort to escape",
+            top_k=100,
+        ),
+        DecodeTestParams(
+            model_id="meta-llama/Meta-Llama-3-8B",
+            sequence_length=256,
+            expected_text=" Winston Smith, his chin nuzzled into his breast in an effort to escape the vile wind,",
+            top_k=100,
+        ),
+        DecodeTestParams(
+            model_id="google/gemma-7b",
+            sequence_length=128,
+            expected_text="\n\nThe time is 1984. The place is Airstrip One, the British",
+        ),
+        DecodeTestParams(
+            model_id="mistralai/Mixtral-8x7B-v0.1",
+            sequence_length=1024,
+            expected_text="\n\nGeorge Orwell, 1984\n\nThe clocks are striking thirteen",
+        ),
+    ],
+    ids=["Llama-2-7b-hf", "Meta-Llama-3-8B", "gemma-7b", "Mixtral-8x7B"],
+)
+def test_decode_single_jetstream_pytorch_slow(params, do_sample):
+    if not jetstream_pt_available():
+        pytest.skip("Jetstream PyTorch is not available")
+    params.do_sample = do_sample
+    decode_single_test(params)
+
+
+@pytest.mark.parametrize("do_sample", [False, True], ids=["greedy", "sample"])
+@pytest.mark.parametrize("params",
+    [
+        DecodeTestParams(
+            model_id="Maykeye/TinyLLama-v0",
+            sequence_length=256,
+            expected_text=" The sun was shining and the sky was shining.\nSuddenly, a big wind came and blew the wind away.",
+            max_new_tokens=25,
+        ),
+        DecodeTestParams(
+            model_id="google/gemma-2b",
+            sequence_length=1024,
+            expected_text="\n\nThe first thing I noticed was the smell of the rain. It was a smell I had never",
+        ),
+        DecodeTestParams(
+            model_id="dacorvo/Mixtral-tiny", # This is a random tiny model, just to test model can be loaded.
+            sequence_length=512,
+            expected_text="манaminationVariableßer Rog malesazine longふ Toy Champions enero Facereverse▲verbose prosecut literally disappearedअ",
+        ),
+    ],
+    ids=["TinyLLama-v0", "gemma-2b", "Mixtral-tiny"],
+)
+def test_decode_single_jetstream_pytorch(params, do_sample):
+    if not jetstream_pt_available():
+        pytest.skip("Jetstream PyTorch is not available")
+    params.do_sample = do_sample
+    decode_single_test(params)

--- a/text-generation-inference/tests/test_decode_jetstream_quant.py
+++ b/text-generation-inference/tests/test_decode_jetstream_quant.py
@@ -1,0 +1,54 @@
+
+import pytest
+from decode_tests_utils import DecodeTestParams, decode_single_test
+
+from optimum.tpu.jetstream_pt_support import jetstream_pt_available
+
+
+@pytest.mark.parametrize("params",
+    [
+        DecodeTestParams(
+            model_id="google/gemma-2b",
+            sequence_length=1024,
+            expected_text="\n\nThe first thing I noticed was the smell of the rain. It was a very heavy rain,",
+        ),
+        DecodeTestParams(
+            model_id="Maykeye/TinyLLama-v0",
+            sequence_length=256,
+            expected_text=" It was a very special day, and it was a very special day.\nThe mommy said to her, \"Let",
+            max_new_tokens=25,
+        ),
+    ],
+    ids=["gemma-2b", "TinyLLama-v0"],
+)
+def test_decode_jetstream_quantization(quantization_jetstream_int8, params):
+    if not jetstream_pt_available():
+        pytest.skip("Jetstream PyTorch is not available")
+    decode_single_test(params)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("params",
+    [
+        DecodeTestParams(
+            model_id="mistralai/Mixtral-8x7B-v0.1",
+            sequence_length=1024,
+            expected_text="\n\nGeorge Orwell, 1984\n\nThe clocks are striking thirteen",
+        ),
+        DecodeTestParams(
+            model_id="meta-llama/Meta-Llama-3-8B",
+            sequence_length=256,
+            expected_text=" Winston Smith, his chin nuzzled into his breast in an effort to escape the vile wind,",
+        ),
+        DecodeTestParams(
+            model_id="meta-llama/Meta-Llama-3-70B",
+            sequence_length=512,
+            expected_text=" Winston Smith,s,s,s,s,s,s,s,s,s,s",
+        ),
+    ],
+    ids=["Mixtral-8x7B", "Meta-Llama-3-8B" ,"Meta-Llama-3-70B"],
+)
+def test_decode_jetstream_quantization_slow(quantization_jetstream_int8, params):
+    if not jetstream_pt_available():
+        pytest.skip("Jetstream PyTorch is not available")
+    decode_single_test(params)


### PR DESCRIPTION
# What does this PR do?

This integrates the `int8` quantization on TGI as supported on Jetstream Pytorch. This allows to fit larger models for serving, such as `mistralai/Mixtral-8x7B-v0.1`.
Note that some unexpected behaviour has been observed on some prompts when using other models, such as `Llama-3-70B`, so a test has been added but the model is not considered ready for deployment with the current implementation.

## Before submitting
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
