### PR TITLE
fix(doc): correct link to deploy page

### DIFF
--- a/docs/source/howto/serving.mdx
+++ b/docs/source/howto/serving.mdx
@@ -8,7 +8,7 @@ that better leverages the underlying hardware, Cloud TPU in this case.
 ## Deploy TGI on Cloud TPU instance
 
 We assume the reader already has a Cloud TPU instance up and running.
-If this is not the case, please see our guide to deploy one [here](./deploy.mdx)
+If this is not the case, please see our guide to deploy one [here](./deploy)
 
 ### Docker Container Build
 


### PR DESCRIPTION
# What does this PR do?

This is just to fix a link in the documentation, pointing to the wrong page for the deploy documentation.

Fixes #113 

- [x] Did you make sure to update the documentation with your changes?
