### PR TITLE
fix(test): correct nightly tests with random sampling

### DIFF
--- a/text-generation-inference/tests/decode_tests_utils.py
+++ b/text-generation-inference/tests/decode_tests_utils.py
@@ -30,6 +30,7 @@ def decode_single_test(params):
         max_new_tokens=max_new_tokens,
         do_sample=params.do_sample,
         top_k=params.top_k,
+        seed=1234,
     )
     batch = Batch(id=0, requests=[request], size=1, max_tokens=params.sequence_length)
     generations, next_batch = generator.prefill(batch)


### PR DESCRIPTION
# What does this PR do?

Since the random sampling has changed, some tests were now broken. It seems that when the seed is 0, the sampling gets really close to whatever the greedy search was doing. To avoid further issues, the seed has been set to something else.

Note this has been validated with https://github.com/huggingface/optimum-tpu/actions/runs/11949379268/job/33308708427
