### PR TITLE
Fix nightlies again

### DIFF
--- a/.github/workflows/test-pytorch-xla-tpu-tgi-nightly.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-nightly.yml
@@ -38,4 +38,4 @@ jobs:
         run: |
           make tgi_server test_installs
           find text-generation-inference/ -name "text_generation_server-*whl" -exec python -m pip install {} \;
-          python -m pytest --runslow -sv text-generation-inference/tests
+          python -m pytest --runslow -sv text-generation-inference/tests -m torch_xla

--- a/text-generation-inference/tests/test_decode_jetstream.py
+++ b/text-generation-inference/tests/test_decode_jetstream.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.jetstream
         DecodeTestParams(
             model_id="google/gemma-7b",
             sequence_length=128,
-            expected_text="\n\nThe time is 1984. The place is Airstrip One, the British",
+            expected_text="\n\nThe year was 1984.\n\nThe place was Oceania.\n\nThe man was",
         ),
         DecodeTestParams(
             model_id="mistralai/Mixtral-8x7B-v0.1",


### PR DESCRIPTION
# What does this PR do?

There were 2 more issues with nightly tests, I hope this one will finish fixing them:
- `gemma-7b` results changed in Jetstream tests too after sampling changes.
- there was a pytest label selector missing.


