### PR TITLE
🔂 Fix repetition penalty

### DIFF
--- a/text-generation-inference/server/text_generation_server/jetstream_pt_support/token_selector.py
+++ b/text-generation-inference/server/text_generation_server/jetstream_pt_support/token_selector.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Union
 
 import jax
 import jax.numpy as jnp
+import torch
 import torch_xla2
 from jetstream.engine import sampling_utils
 from transformers.generation import (
@@ -176,8 +177,9 @@ class TokenSelector:
         """
         # Logits processors is written in pytorch, so parameters are cast to float32 and  converted to pytorch and back
         # to jax with j2t/t2j (that is a bit expensive, it does copies), otherwise some operations are not supported.
-        logits_t = torch_xla2.tensor.j2t(logits.astype(jnp.float32))
-        scores = self.logits_processor(input_ids, logits_t)
+        logits_pt = torch_xla2.tensor.j2t(logits.astype(jnp.float32))
+        input_ids_pt = torch_xla2.tensor.j2t(input_ids).unsqueeze(dim=0).to(torch.int64)
+        scores = self.logits_processor(input_ids_pt, logits_pt)
         scores = torch_xla2.tensor.t2j(scores).to_device(logits.device)
 
         if self.mode == GenerationMode.SAMPLE:

--- a/text-generation-inference/tests/decode_tests_utils.py
+++ b/text-generation-inference/tests/decode_tests_utils.py
@@ -14,7 +14,7 @@ class DecodeTestParams:
     do_sample: bool = False
     max_new_tokens: int = 20
     top_k: int = 50
-
+    repetition_penalty: float = 1.0
 
 def decode_single_test(params):
     model_path = prepare_model(params.model_id, params.sequence_length)
@@ -31,6 +31,7 @@ def decode_single_test(params):
         do_sample=params.do_sample,
         top_k=params.top_k,
         seed=1234,
+        repetition_penalty=params.repetition_penalty,
     )
     batch = Batch(id=0, requests=[request], size=1, max_tokens=params.sequence_length)
     generations, next_batch = generator.prefill(batch)

--- a/text-generation-inference/tests/test_decode_jetstream.py
+++ b/text-generation-inference/tests/test_decode_jetstream.py
@@ -65,3 +65,14 @@ def test_decode_single_jetstream_pytorch_slow(params, do_sample):
 def test_decode_single_jetstream_pytorch(params, do_sample):
     params.do_sample = do_sample
     decode_single_test(params)
+
+
+def test_decode_repetition_penalty_jetstream_pytorch():
+    """Test if the repetition penalty generates something without crashing."""
+    params = DecodeTestParams(
+            model_id="Maykeye/TinyLLama-v0",
+            sequence_length=256,
+            expected_text=" The sun was shining and it was very hot.\nSuddenly, a big wind came and",
+            repetition_penalty=1.2
+        )
+    decode_single_test(params)

--- a/text-generation-inference/tests/test_generator_slot.py
+++ b/text-generation-inference/tests/test_generator_slot.py
@@ -64,7 +64,7 @@ def test_decode_streaming_jetstream(tokenizer, input_text, generated_text):
     from text_generation_server.jetstream_pt_support.generator import Slot
 
     slot = Slot(0, tokenizer)
-    _test_decode_streaming(slot, "np", tokenizer, input_text, generated_text)
+    _test_decode_streaming(slot, "pt", tokenizer, input_text, generated_text)
 
 @pytest.mark.torch_xla
 def test_decode_streaming(tokenizer, input_text, generated_text):


### PR DESCRIPTION
# What does this PR do?

The generator was crashing when the request parameter container a repetition_penalty > 1.0. This was due to the logits processor expecting params to be torch tensors. 
So this is now fixed, and a test has been added to detect any possible regression.
