### PR TITLE
Allow sharding fine tuned misaligned models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ style_check:
 	ruff check .
 
 style:
+	ruff check . --fix
 
 # Utilities to release to PyPi
 build_dist_install_tools:

--- a/text-generation-inference/tests/test_decode_jetstream.py
+++ b/text-generation-inference/tests/test_decode_jetstream.py
@@ -59,8 +59,13 @@ def test_decode_single_jetstream_pytorch_slow(params, do_sample):
             sequence_length=512,
             expected_text="манaminationVariableßer Rog malesazine longふ Toy Champions enero Facereverse▲verbose prosecut literally disappearedअ",
         ),
+        DecodeTestParams(
+            model_id="Trendyol/Trendyol-LLM-7b-base-v0.1",
+            sequence_length=512,
+            expected_text="\nThe clocks were striking thirteen, and the clocks were striking thirteen.",
+        ),
     ],
-    ids=["TinyLLama-v0", "gemma-2b", "Mixtral-tiny"],
+    ids=["TinyLLama-v0", "gemma-2b", "Mixtral-tiny", "Trendyol-LLM-7b-base-v0.1"],
 )
 def test_decode_single_jetstream_pytorch(params, do_sample):
     params.do_sample = do_sample


### PR DESCRIPTION
# What does this PR do?

When loading large models, weights are sharded across a mesh of TPUs,
splitting the original weights into smaller tensors, each one with the
same shape.
This is not possible, however, if the original weights shape is not
divisible across the number of TPUs, because it results in a smaller
tensor for the last TPU.
This change pads the tensor with zeros, making it splittable across the
TPUs.

I expected this to cause a change in the model, but apparently that is not the case, and the model still has the same shape and produces a correct output. I suspect this might be due to the way the weight is loaded on the mesh, and the fact that the model figures out the part it should use, but I hadn't got the change to try many "misaligned" models,
the only one I used here it works now. 

Fixes #67 

## Before submitting
- [x] Did you write any new necessary tests?
