### PR TITLE
🦙 Newer Llamas support

### DIFF
--- a/.github/workflows/test-pytorch-xla-tpu-tgi-nightly-jetstream.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-nightly-jetstream.yml
@@ -55,6 +55,10 @@ jobs:
         run: |
           python -m \
             pytest -sv text-generation-inference/tests/test_decode_jetstream_quant.py --runslow -m jetstream -k "slow and Llama-3-70B"
+      - name: Run TGI Jetstream Pytorch - Quantization Llama 3.3 70B
+        run: |
+          python -m \
+            pytest -sv text-generation-inference/tests/test_decode_jetstream_quant.py --runslow -m jetstream -k "slow and Llama-3.3-70B"
       - name: Run TGI Jetstream Pytorch - Other tests
         run: |
           python -m \

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ working closely with Google and Google Cloud to make this a reality.
 
 We currently support a few LLM models targeting text generation scenarios:
 - 💎 Gemma (2b, 7b)
-- 🦙 Llama2 (7b) and Llama3 (8b)
+- 🦙 Llama2 (7b) and Llama3 (8b). On Text Generation Inference with Jetstream Pytorch, also Llama3.1, Llama3.2 and Llama3.3 (text-only models) are supported, up to 70B parameters.
 - 💨 Mistral (7b)
 
 

--- a/docs/source/howto/serving.mdx
+++ b/docs/source/howto/serving.mdx
@@ -56,6 +56,6 @@ curl localhost/generate_stream \
 If for some reason you want to use the Pytorch/XLA backend instead, you can set the `JETSTREAM_PT_DISABLE=1` environment variable.
 
 
-When using Jetstream Pytorch engine, it is possible to enable quantization to reduce the memory footprint and increase the throughput. To enable quantization, set the `QUANTIZATION=1` environment variable.
+When using Jetstream Pytorch engine, it is possible to enable quantization to reduce the memory footprint and increase the throughput. To enable quantization, set the `QUANTIZATION=1` environment variable. For instance, on a 2x4 TPU v5e, you can serve models up to 70B parameters such as Llama 3.3-70B.
 
 ***Note: Quantization is still experimental and may produce lower quality results compared to the non-quantized version.***

--- a/optimum/tpu/jetstream_pt_support.py
+++ b/optimum/tpu/jetstream_pt_support.py
@@ -1,7 +1,4 @@
 import os
-import sys
-
-from loguru import logger
 
 
 def jetstream_pt_available() -> bool:
@@ -11,10 +8,6 @@ def jetstream_pt_available() -> bool:
         # Jetstream Pytorch is enabled by default, it can be disabled with an ENV variable.
         jetstream_pt_disabled = os.environ.get("JETSTREAM_PT_DISABLE", False) == "1"
         if jetstream_pt_disabled:
-            return False
-        # Torch XLA should not be imported before torch_xla2 to avoid conflicts.
-        if 'torch_xla2' not in sys.modules and 'torch_xla.core' in sys.modules:
-            logger.warning("torch_xla2 cannot be imported after torch_xla, disabling Jetstream PyTorch support.")
             return False
         # Import torch_xla2 first!
         import torch_xla2  # noqa: F401, isort:skip

--- a/text-generation-inference/server/text_generation_server/jetstream_pt_support/models/llama_model_exportable_hf.py
+++ b/text-generation-inference/server/text_generation_server/jetstream_pt_support/models/llama_model_exportable_hf.py
@@ -96,6 +96,10 @@ class TransformerHf(Transformer, GenerationMixin):
         ffn_dim_multiplier = config.intermediate_size / int(8 * config.hidden_size / 3)
         multiple_of = 1
 
+        if config.mlp_bias:
+            raise ValueError("MLP bias is not supported in the on Jetstream Pytorch."
+                             + "If your model requires it, you can open an issue.")
+
         rope_scaling_js = None
         rope_scaling = config.rope_scaling
         # The original Llama2 and Llama3 models do not have rope scaling configuration, while newer models do.

--- a/text-generation-inference/server/text_generation_server/jetstream_pt_support/models/llama_model_exportable_hf.py
+++ b/text-generation-inference/server/text_generation_server/jetstream_pt_support/models/llama_model_exportable_hf.py
@@ -1,6 +1,79 @@
+import dataclasses
+import math
+from contextlib import contextmanager
+from functools import partial
 
+import torch
+from jetstream_pt.third_party.llama import model_exportable
 from jetstream_pt.third_party.llama.model_exportable import Transformer, model_args
 from transformers import GenerationConfig, GenerationMixin, LlamaConfig
+
+
+# TODO: it would be better to have RoPE scaling code in Jetstream Pytorch, but until that is not done,
+# we add it here. Note that this is the reason why we define a new class RopeScalingArgs, instead of using the
+# config from transformers.
+@dataclasses.dataclass
+class RopeScalingArgs:
+  """Rope scaling configuration parameters."""
+
+  factor: float = 8.0
+  low_freq_factor: float = 1.0
+  high_freq_factor: float = 4.0
+  original_max_position_embeddings: int = 8192
+
+
+def apply_scaling(freqs: torch.Tensor, config: RopeScalingArgs):
+    # Values obtained from grid search
+    scale_factor = config.factor
+    low_freq_factor = config.low_freq_factor
+    high_freq_factor = config.high_freq_factor
+    old_context_len = config.original_max_position_embeddings
+
+    low_freq_wavelen = old_context_len / low_freq_factor
+    high_freq_wavelen = old_context_len / high_freq_factor
+    new_freqs = []
+    for freq in freqs:
+        wavelen = 2 * math.pi / freq
+        if wavelen < high_freq_wavelen:
+            new_freqs.append(freq)
+        elif wavelen > low_freq_wavelen:
+            new_freqs.append(freq / scale_factor)
+        else:
+            assert low_freq_wavelen != high_freq_wavelen
+            smooth = (old_context_len / wavelen - low_freq_factor) / (
+                  high_freq_factor - low_freq_factor
+            )
+            new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
+    return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
+
+
+def precompute_freqs_cis(
+    dim: int,
+    end: int,
+    theta: float = 10000.0,
+    rope_scaling_config: RopeScalingArgs = None,
+):
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
+    t = torch.arange(end, device=freqs.device, dtype=torch.float32)
+    if rope_scaling_config is not None:
+        freqs = apply_scaling(freqs, rope_scaling_config)
+    freqs = torch.outer(t, freqs)
+    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)  # complex64
+    return freqs_cis
+
+
+@contextmanager
+def patch_precompute_freqs_cis(rope_scaling_js: RopeScalingArgs):
+    # NOTE: This is a workaround to pass the rope scaling configuration when it is called in the original
+    # Jetstream/Pytorch model. The function is monkey-patched to include the rope scaling configuration.
+    original_precompute_freqs_cis = model_exportable.precompute_freqs_cis
+    precompute_freqs_cis_partial = partial(precompute_freqs_cis, rope_scaling_config=rope_scaling_js)
+    model_exportable.precompute_freqs_cis = precompute_freqs_cis_partial
+
+    yield
+
+    # Original function is restored.
+    model_exportable.precompute_freqs_cis = original_precompute_freqs_cis
 
 
 class TransformerHf(Transformer, GenerationMixin):
@@ -23,6 +96,22 @@ class TransformerHf(Transformer, GenerationMixin):
         ffn_dim_multiplier = config.intermediate_size / int(8 * config.hidden_size / 3)
         multiple_of = 1
 
+        rope_scaling_js = None
+        rope_scaling = config.rope_scaling
+        # The original Llama2 and Llama3 models do not have rope scaling configuration, while newer models do.
+        if rope_scaling is not None:
+            # Some models use "type" instead of "rope_type" in the configuration for historical reasons.
+            rope_type = rope_scaling.get("rope_type", rope_scaling.get("type", None))
+            if rope_type != "llama3":
+                raise ValueError(f"Unsupported rope type {rope_type} in rope scaling configuration.")
+
+            rope_scaling_js = RopeScalingArgs(
+                factor=rope_scaling["factor"],
+                low_freq_factor=rope_scaling["low_freq_factor"],
+                high_freq_factor=rope_scaling["high_freq_factor"],
+                original_max_position_embeddings=rope_scaling["original_max_position_embeddings"],
+            )
+
         args = model_args.ModelArgs(
             dim=config.hidden_size,
             n_layers=config.num_hidden_layers,
@@ -37,7 +126,9 @@ class TransformerHf(Transformer, GenerationMixin):
             rope_theta=config.rope_theta,
         )
         args.device = device
-        super().__init__(args, env)
+
+        with patch_precompute_freqs_cis(rope_scaling_js):
+            super().__init__(args, env)
 
 
     @classmethod

--- a/text-generation-inference/tests/conftest.py
+++ b/text-generation-inference/tests/conftest.py
@@ -38,7 +38,7 @@ def quantization_jetstream_int8():
 
 
 def pytest_runtest_setup(item):
-    marker_names = [marker.name for marker in item.own_markers]
+    marker_names = [marker.name for marker in item.iter_markers()]
     jetstream_pt_enabled = jetstream_pt_available()
     # Skip tests that require torch xla but not jetstream
     if "torch_xla" in marker_names and "jetstream" not in marker_names:

--- a/text-generation-inference/tests/test_decode_jetstream.py
+++ b/text-generation-inference/tests/test_decode_jetstream.py
@@ -65,8 +65,14 @@ def test_decode_single_jetstream_pytorch_slow(params, do_sample):
             sequence_length=512,
             expected_text="\nThe clocks were striking thirteen, and the clocks were striking thirteen.",
         ),
+        DecodeTestParams(
+            model_id="meta-llama/Llama-3.2-1B",
+            sequence_length=256,
+            expected_text=" Winston Smith, his chin nuzzled into his breast, stretched, and looked out across the city",
+            max_new_tokens=20,
+        )
     ],
-    ids=["TinyLLama-v0", "gemma-2b", "Mixtral-tiny", "Trendyol-LLM-7b-base-v0.1"],
+    ids=["TinyLLama-v0", "gemma-2b", "Mixtral-tiny", "Trendyol-LLM-7b-base-v0.1", "Llama-3.2-1B"],
 )
 def test_decode_single_jetstream_pytorch(params, do_sample):
     params.do_sample = do_sample

--- a/text-generation-inference/tests/test_decode_jetstream.py
+++ b/text-generation-inference/tests/test_decode_jetstream.py
@@ -60,6 +60,7 @@ def test_decode_single_jetstream_pytorch_slow(params, do_sample):
             expected_text="манaminationVariableßer Rog malesazine longふ Toy Champions enero Facereverse▲verbose prosecut literally disappearedअ",
         ),
         DecodeTestParams(
+            # NOTE: this test is interesting because it is a fine-tuned model that requires padding on weights to work.
             model_id="Trendyol/Trendyol-LLM-7b-base-v0.1",
             sequence_length=512,
             expected_text="\nThe clocks were striking thirteen, and the clocks were striking thirteen.",

--- a/text-generation-inference/tests/test_decode_jetstream_quant.py
+++ b/text-generation-inference/tests/test_decode_jetstream_quant.py
@@ -44,8 +44,13 @@ def test_decode_jetstream_quantization(quantization_jetstream_int8, params):
             sequence_length=512,
             expected_text=" Winston Smith,s,s,s,s,s,s,s,s,s,s",
         ),
+        DecodeTestParams(
+            model_id="meta-llama/Llama-3.3-70B-Instruct",
+            sequence_length=1024,
+            expected_text=" Winston Smith, the protagonist of the story, was slowly getting up from bed. He stretched his arms",
+        ),
     ],
-    ids=["Mixtral-8x7B", "Meta-Llama-3-8B" ,"Meta-Llama-3-70B"],
+    ids=["Mixtral-8x7B", "Meta-Llama-3-8B" ,"Meta-Llama-3-70B", "Llama-3.3-70B-Instruct"],
 )
 def test_decode_jetstream_quantization_slow(quantization_jetstream_int8, params):
     decode_single_test(params)


### PR DESCRIPTION
# What does this PR do?

This PR mainly adds support for RoPE scaling to Jetstream Pytorch Llama models, that is required to support newer Llama models on TGI, such as Llama 3.1, Llama 3.2 and Llama 3.3.
Note that Llama3.3 is a 70B model, so quantization should be enabled to serve it.

## Before submitting
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
