### PR TITLE
doc(v6e): mention initial v6e support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We currently support a few LLM models targeting text generation scenarios:
 ## Inference
 
 `optimum-tpu` provides a set of dedicated tools and integrations in order to leverage Cloud TPUs for inference, especially
-on the latest TPU version `v5e`. 
+on the latest TPU version `v5e` and `v6e`.
 
 Other TPU versions will be supported along the way.
 
@@ -64,8 +64,8 @@ To enable the support, export the environment variable `JETSTREAM_PT=1`.
 
 Fine-tuning is supported and tested on the TPU `v5e`. We have tested so far:
 
-- 🦙 Llama-2 7B and Llama-3 8B
-- 💎 Gemma 2B and 7B
+- 🦙 Llama-2 7B, Llama-3 8B and newer;
+- 💎 Gemma 2B and 7B.
 
 You can check the examples:
 

--- a/docs/source/howto/training.mdx
+++ b/docs/source/howto/training.mdx
@@ -4,14 +4,17 @@ Welcome to the 🤗 Optimum-TPU training guide! This section covers how to fine-
 
 ## Currently Supported Models
 
-The following models have been tested and validated for fine-tuning on TPU v5e:
+The following models have been tested and validated for fine-tuning on TPU `v5e` and `v6e`:
 
 - 🦙 LLaMA Family
   - LLaMA-2 7B
   - LLaMA-3 8B
+  - LLaMA-3.2 1B
 - 💎 Gemma Family
   - Gemma 2B
   - Gemma 7B
+
+Bigger models are supported, but not yet tested.
 
 ## Getting Started
 


### PR DESCRIPTION
# What does this PR do?

Since we tested optimum-tpu and TGI on v6e, we mention it.