### PR TITLE
chore(ci): disable nightly tests

### DIFF
--- a/.github/workflows/test-pytorch-xla-tpu-tgi-integration.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-integration.yml
@@ -1,9 +1,9 @@
 name: Optimum TPU / Test TGI on TPU / Integration Tests
 
 on:
-  schedule:
-    - cron: '0 4 * * *' # run at 4 AM UTC
-    # This can be used to allow manually triggering nightlies from the web interface
+  # schedule:
+  #   - cron: '0 4 * * *' # run at 4 AM UTC
+  #   # This can be used to allow manually triggering nightlies from the web interface
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-pytorch-xla-tpu-tgi-nightly-jetstream.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-nightly-jetstream.yml
@@ -1,8 +1,8 @@
 name: Optimum TPU / Test TGI on TPU (slow tests) / Jetstream Pytorch
 
 on:
-  schedule:
-  - cron: '0 3 * * *' # run at 3 AM UTC
+  # schedule:
+  # - cron: '0 3 * * *' # run at 3 AM UTC
   # This can be used to allow manually triggering nightlies from the web interface
   workflow_dispatch:
 

--- a/.github/workflows/test-pytorch-xla-tpu-tgi-nightly.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-nightly.yml
@@ -2,8 +2,8 @@ name: Optimum TPU / Test TGI on TPU (slow tests)
 
 on:
   # This can be used to automatically publish nightlies at UTC nighttime
-  schedule:
-  - cron: '0 2 * * *' # run at 2 AM UTC
+  # schedule:
+  # - cron: '0 2 * * *' # run at 2 AM UTC
   # This can be used to allow manually triggering nightlies from the web interface
   workflow_dispatch:
 


### PR DESCRIPTION
# What does this PR do?

Disable nightly tests by commenting out the cron, as we do not expect much activity on the repo for now. The `workflow_dispatch` is still available in case of need.