### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/check_code_quality.yml
+++ b/.github/workflows/check_code_quality.yml
@@ -31,9 +31,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Create and start a virtual environment

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -24,8 +24,8 @@ jobs:
       PR_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache-dependency-path: "kit/package-lock.json"

--- a/.github/workflows/doc-pr-build.yml
+++ b/.github/workflows/doc-pr-build.yml
@@ -23,8 +23,8 @@ jobs:
       PR_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache-dependency-path: "kit/package-lock.json"
@@ -49,7 +49,7 @@ jobs:
           echo ${{ env.COMMIT_SHA }} > ./commit_sha
           echo ${{ env.PR_NUMBER }} > ./pr_number
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: doc-build-artifact
           path: tpu-doc-build/

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: pip install -U build twine

--- a/.github/workflows/secrets-leak.yml
+++ b/.github/workflows/secrets-leak.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Secret Scanning

--- a/.github/workflows/test-pytorch-xla-tpu-tgi-integration.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-integration.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Python
         run: |

--- a/.github/workflows/test-pytorch-xla-tpu-tgi-jetstream.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-jetstream.yml
@@ -29,7 +29,7 @@ jobs:
       HF_HUB_CACHE: /mnt/hf_cache/cache_huggingface
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build and test TGI server
         run: |

--- a/.github/workflows/test-pytorch-xla-tpu-tgi-nightly-jetstream.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-nightly-jetstream.yml
@@ -25,7 +25,7 @@ jobs:
       JETSTREAM_PT: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build and install Jetstream Pytorch TGI
         run: |

--- a/.github/workflows/test-pytorch-xla-tpu-tgi-nightly.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi-nightly.yml
@@ -26,7 +26,7 @@ jobs:
       JETSTREAM_PT_DISABLE: 1 # Disable PyTorch to avoid conflicts with PyTorch XLA
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build and test Optimum TPU (also slow tests)
         run: |

--- a/.github/workflows/test-pytorch-xla-tpu-tgi.yml
+++ b/.github/workflows/test-pytorch-xla-tpu-tgi.yml
@@ -28,7 +28,7 @@ jobs:
       JETSTREAM_PT_DISABLE: 1 # Disable PyTorch to avoid conflicts with PyTorch XLA
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build and test TGI server
         run: |

--- a/.github/workflows/test-pytorch-xla-tpu.yml
+++ b/.github/workflows/test-pytorch-xla-tpu.yml
@@ -28,7 +28,7 @@ jobs:
       JETSTREAM_PT_DISABLE: 1 # Disable PyTorch to avoid conflicts with PyTorch XLA
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build and test optimum tpu
         run: |

--- a/.github/workflows/tpu-tgi-release.yml
+++ b/.github/workflows/tpu-tgi-release.yml
@@ -20,7 +20,7 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}
     steps:
         - name: Check out the repo
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
 
         - name: Log in to Docker Hub
           uses: docker/login-action@v3


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v3`](https://github.com/actions/checkout/releases/tag/v3), [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | check_code_quality.yml, doc-build.yml, doc-pr-build.yml, pypi-release.yaml, secrets-leak.yml, test-pytorch-xla-tpu-tgi-integration.yml, test-pytorch-xla-tpu-tgi-jetstream.yml, test-pytorch-xla-tpu-tgi-nightly-jetstream.yml, test-pytorch-xla-tpu-tgi-nightly.yml, test-pytorch-xla-tpu-tgi.yml, test-pytorch-xla-tpu.yml, tpu-tgi-release.yml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | doc-build.yml, doc-pr-build.yml |
| `actions/setup-python` | [`v2`](https://github.com/actions/setup-python/releases/tag/v2) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | check_code_quality.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | doc-pr-build.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
